### PR TITLE
Refine round flow with sequential hidden picks

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -216,6 +216,7 @@ const App = () => {
       </header>
 
       <main className="app-stack">
+        <HowToPlayCard />
         <DareComposer players={players} disabled={Boolean(activeRound)} onLaunch={launchRound} />
         <ActiveRoundStage
           round={activeRound}
@@ -229,7 +230,6 @@ const App = () => {
         <PlayerRoster players={players} onAdd={addPlayer} onRemove={removePlayer} />
         <HistoryPanel history={history} players={players} />
         <StatsPanel players={players} roundsPlayed={roundsLaunched} />
-        <HowToPlayCard />
       </main>
     </div>
   );

--- a/src/index.css
+++ b/src/index.css
@@ -526,6 +526,90 @@ textarea {
   font-size: 0.85rem;
 }
 
+.active-round__steps {
+  display: grid;
+  gap: 16px;
+}
+
+.active-round__step {
+  border-radius: var(--radius-md);
+  border: 1px solid rgba(148, 163, 184, 0.22);
+  background: rgba(148, 163, 184, 0.1);
+  padding: 18px;
+  display: grid;
+  gap: 16px;
+}
+
+.active-round__step--highlight {
+  border-color: rgba(139, 92, 246, 0.48);
+  background: rgba(139, 92, 246, 0.14);
+}
+
+.active-round__step.is-complete {
+  border-color: rgba(148, 163, 184, 0.32);
+  background: rgba(148, 163, 184, 0.16);
+}
+
+.active-round__step-header {
+  display: flex;
+  gap: 12px;
+  align-items: center;
+}
+
+.active-round__step-number {
+  width: 36px;
+  height: 36px;
+  border-radius: 50%;
+  display: grid;
+  place-items: center;
+  font-weight: 600;
+  background: rgba(148, 163, 184, 0.18);
+  color: var(--text-primary);
+}
+
+.active-round__step--highlight .active-round__step-number {
+  background: rgba(139, 92, 246, 0.24);
+  color: var(--accent);
+}
+
+.active-round__step-title {
+  margin: 0;
+  font-weight: 600;
+}
+
+.active-round__step-subtitle {
+  margin: 4px 0 0;
+  font-size: 0.85rem;
+  color: var(--text-muted);
+}
+
+.active-round__step-body {
+  display: grid;
+  gap: 14px;
+}
+
+.active-round__form {
+  display: grid;
+  gap: 12px;
+}
+
+.active-round__form-label {
+  font-size: 0.85rem;
+  color: var(--text-muted);
+}
+
+.active-round__error {
+  margin: 0;
+  font-size: 0.82rem;
+  color: #fca5a5;
+}
+
+.active-round__step-message {
+  margin: 0;
+  font-size: 0.95rem;
+  color: var(--text-secondary);
+}
+
 .active-round__matchup {
   display: grid;
   gap: 16px;
@@ -588,6 +672,33 @@ textarea {
 .active-round__resolution {
   display: grid;
   gap: 10px;
+}
+
+.active-round__summary {
+  display: grid;
+  grid-template-columns: repeat(2, minmax(0, 1fr));
+  gap: 12px;
+}
+
+.active-round__summary-item {
+  border-radius: var(--radius-md);
+  border: 1px solid rgba(148, 163, 184, 0.2);
+  background: rgba(15, 23, 42, 0.6);
+  padding: 12px;
+  display: grid;
+  gap: 6px;
+}
+
+.active-round__summary-label {
+  font-size: 0.8rem;
+  text-transform: uppercase;
+  letter-spacing: 0.16em;
+  color: var(--text-muted);
+}
+
+.active-round__summary-value {
+  font-size: 1.3rem;
+  font-weight: 600;
 }
 
 .active-round__resolved-note {


### PR DESCRIPTION
## Summary
- guide players through a sequential picking flow that keeps each number hidden until the countdown
- add step-based styling and reveal summaries to support the new interaction
- surface the How to Play card at the top of the main stack for quick reference

## Testing
- npm run build
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68d3bf0ce734832c9a05f3ebc37bb9dd