### PR TITLE
Turn how-to steps into guided flow

### DIFF
--- a/src/components/HowToPlayCard.tsx
+++ b/src/components/HowToPlayCard.tsx
@@ -1,4 +1,80 @@
+import { useEffect, useState } from "react";
+
+const ADVANCE_DELAY_MS = 800;
+const RESTART_DELAY_MS = 2200;
+
+const HOW_TO_STEPS = [
+  {
+    title: "Challenge",
+    description:
+      "A player dares someone and proposes the odds (for example 1 in 8). Make the dare tempting enough to accept!",
+  },
+  {
+    title: "Accept",
+    description:
+      "The target agrees to the dare and both silently pick a number in the range. No peeking while the countdown is on!",
+  },
+  {
+    title: "Reveal",
+    description:
+      "Count down from three and show numbers. If they match, the target carries out the dare with pride and style.",
+  },
+  {
+    title: "Escalate",
+    description:
+      "If it feels too easy, lower the odds or remix the dare. Keep it fun, consensual, and safe for everyone involved.",
+  },
+];
+
 const HowToPlayCard = () => {
+  const steps = HOW_TO_STEPS;
+  const [stepIndex, setStepIndex] = useState(0);
+  const [isAdvancing, setIsAdvancing] = useState(false);
+  const [isComplete, setIsComplete] = useState(false);
+
+  useEffect(() => {
+    if (!isAdvancing) return;
+
+    const timer = window.setTimeout(() => {
+      setIsAdvancing(false);
+      setStepIndex((current) => {
+        const next = current + 1;
+        if (next >= steps.length) {
+          setIsComplete(true);
+          return current;
+        }
+        return next;
+      });
+    }, ADVANCE_DELAY_MS);
+
+    return () => window.clearTimeout(timer);
+  }, [isAdvancing, steps.length]);
+
+  useEffect(() => {
+    if (!isComplete) return;
+
+    const timer = window.setTimeout(() => {
+      setIsComplete(false);
+      setStepIndex(0);
+    }, RESTART_DELAY_MS);
+
+    return () => window.clearTimeout(timer);
+  }, [isComplete]);
+
+  const handleCompleteStep = () => {
+    if (isAdvancing || isComplete) return;
+    setIsAdvancing(true);
+  };
+
+  const completedSteps = isComplete
+    ? steps.length
+    : stepIndex + (isAdvancing ? 1 : 0);
+  const progress = Math.min((completedSteps / steps.length) * 100, 100);
+  const activeStep = steps[stepIndex];
+  const progressLabel = isComplete
+    ? "Guide complete! Restarting…"
+    : `Step ${stepIndex + 1} of ${steps.length}`;
+
   return (
     <section className="panel howto">
       <header className="panel__header">
@@ -7,20 +83,41 @@ const HowToPlayCard = () => {
           <h2 className="panel__title">How to play</h2>
         </div>
       </header>
-      <ol className="howto__steps">
-        <li>
-          <strong>Challenge:</strong> A player dares someone and proposes the odds (for example 1 in 8).
-        </li>
-        <li>
-          <strong>Accept:</strong> The target agrees to the dare and both silently pick a number in the range.
-        </li>
-        <li>
-          <strong>Reveal:</strong> Count down from three and show numbers. If they match, the target does the dare.
-        </li>
-        <li>
-          <strong>Escalate:</strong> If it feels too easy, lower the odds or remix the dare. Keep it fun and safe!
-        </li>
-      </ol>
+      <div className="howto__carousel">
+        <div className="howto__progress">
+          <div className="howto__progress-track" aria-hidden="true">
+            <span className="howto__progress-bar" style={{ width: `${progress}%` }} />
+          </div>
+          <span className="howto__progress-label" aria-live="polite">
+            {progressLabel}
+          </span>
+        </div>
+        {isComplete ? (
+          <div className="howto__complete" role="status" aria-live="polite">
+            <h3 className="howto__complete-title">You're ready to play!</h3>
+            <p className="howto__complete-copy">
+              Nice work finishing the walkthrough. We'll start it again automatically so the next player can follow
+              along.
+            </p>
+          </div>
+        ) : (
+          <article className={`howto__slide${isAdvancing ? " howto__slide--advancing" : ""}`}>
+            <p className="howto__slide-eyebrow">Step {stepIndex + 1}</p>
+            <h3 className="howto__slide-title">{activeStep.title}</h3>
+            <p className="howto__slide-copy">{activeStep.description}</p>
+            <div className="howto__actions">
+              <button
+                type="button"
+                className="button"
+                onClick={handleCompleteStep}
+                disabled={isAdvancing}
+              >
+                {stepIndex === steps.length - 1 ? "Finish guide" : "Mark step complete"}
+              </button>
+            </div>
+          </article>
+        )}
+      </div>
       <p className="howto__tip">
         Tip: The lower the odds, the more likely the dare triggers. Use the sweetener field to add rewards or twists.
       </p>

--- a/src/index.css
+++ b/src/index.css
@@ -929,16 +929,113 @@ textarea {
   font-size: 0.85rem;
 }
 
-.howto__steps {
-  margin: 0;
-  padding-left: 20px;
+.howto__carousel {
   display: grid;
-  gap: 10px;
-  color: var(--text-secondary);
+  gap: 16px;
 }
 
-.howto__steps li {
+.howto__progress {
+  display: grid;
+  gap: 6px;
+}
+
+.howto__progress-track {
+  width: 100%;
+  height: 6px;
+  background: rgba(148, 163, 184, 0.18);
+  border-radius: 999px;
+  overflow: hidden;
+}
+
+.howto__progress-bar {
+  display: block;
+  height: 100%;
+  border-radius: inherit;
+  background: linear-gradient(135deg, #8b5cf6, #6366f1);
+  transition: width 0.35s ease;
+}
+
+.howto__progress-label {
+  font-size: 0.72rem;
+  text-transform: uppercase;
+  letter-spacing: 0.2em;
+  color: var(--text-muted);
+}
+
+.howto__slide {
+  border-radius: var(--radius-md);
+  border: 1px solid rgba(148, 163, 184, 0.2);
+  background: rgba(15, 23, 42, 0.62);
+  box-shadow: inset 0 0 0 1px rgba(15, 23, 42, 0.18);
+  padding: 22px;
+  display: grid;
+  gap: 12px;
+  min-height: 176px;
+  transition: transform 0.35s ease, opacity 0.3s ease;
+}
+
+.howto__slide--advancing {
+  opacity: 0.55;
+  transform: translateX(-6px);
+}
+
+.howto__slide-eyebrow {
+  margin: 0;
+  font-size: 0.68rem;
+  text-transform: uppercase;
+  letter-spacing: 0.22em;
+  color: var(--text-muted);
+}
+
+.howto__slide-title {
+  margin: 0;
+  font-size: 1.25rem;
+  font-weight: 600;
+}
+
+.howto__slide-copy {
+  margin: 0;
   font-size: 0.95rem;
+  color: var(--text-secondary);
+  line-height: 1.55;
+}
+
+.howto__actions {
+  margin-top: 4px;
+}
+
+.howto__complete {
+  border-radius: var(--radius-md);
+  border: 1px solid rgba(139, 92, 246, 0.32);
+  background: rgba(67, 56, 202, 0.35);
+  padding: 24px;
+  display: grid;
+  gap: 10px;
+  position: relative;
+  overflow: hidden;
+}
+
+.howto__complete::after {
+  content: "";
+  position: absolute;
+  inset: -40% auto auto 30%;
+  width: 260px;
+  height: 260px;
+  background: radial-gradient(circle at center, rgba(139, 92, 246, 0.35), transparent 70%);
+  opacity: 0.65;
+  pointer-events: none;
+}
+
+.howto__complete-title {
+  margin: 0;
+  font-size: 1.22rem;
+  font-weight: 600;
+}
+
+.howto__complete-copy {
+  margin: 0;
+  font-size: 0.95rem;
+  color: var(--text-secondary);
 }
 
 .howto__tip {


### PR DESCRIPTION
## Summary
- replace the static instructions card with a guided multi-step walkthrough that only shows one step at a time
- add automatic progression with a progress bar, completion messaging, and a timed reset for the how-to guide
- update styling to support the new carousel layout and completion state

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68d3c1175cb8832c9d821204ba7ff280