### PR TITLE
Reorder player setup and remove default roster

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -28,14 +28,8 @@ const createPlayer = (name: string, icon: string, color: string): Player => ({
   daresCompleted: 0,
 });
 
-const initialPlayers: Player[] = [
-  createPlayer("Alex", "🎲", "#7C3AED"),
-  createPlayer("Blair", "⚡️", "#22C55E"),
-  createPlayer("Casey", "🔥", "#F97316"),
-];
-
 const App = () => {
-  const [players, setPlayers] = useState<Player[]>(initialPlayers);
+  const [players, setPlayers] = useState<Player[]>([]);
   const [activeRound, setActiveRound] = useState<ActiveRound | null>(null);
   const [history, setHistory] = useState<RoundHistoryEntry[]>([]);
   const [roundsLaunched, setRoundsLaunched] = useState<number>(0);
@@ -217,6 +211,7 @@ const App = () => {
 
       <main className="app-stack">
         <HowToPlayCard />
+        <PlayerRoster players={players} onAdd={addPlayer} onRemove={removePlayer} />
         <DareComposer players={players} disabled={Boolean(activeRound)} onLaunch={launchRound} />
         <ActiveRoundStage
           round={activeRound}
@@ -227,7 +222,6 @@ const App = () => {
           onCancel={cancelRound}
           onArchive={archiveRound}
         />
-        <PlayerRoster players={players} onAdd={addPlayer} onRemove={removePlayer} />
         <HistoryPanel history={history} players={players} />
         <StatsPanel players={players} roundsPlayed={roundsLaunched} />
       </main>

--- a/src/components/DareComposer.tsx
+++ b/src/components/DareComposer.tsx
@@ -32,15 +32,16 @@ const DareComposer = ({ players, disabled, onLaunch }: DareComposerProps) => {
       return;
     }
 
-    if (!players.some((player) => player.id === challengerId)) {
-      setChallengerId(players[0].id);
+    if (challengerId && !players.some((player) => player.id === challengerId)) {
+      setChallengerId("");
     }
 
-    const fallbackTarget = players.find((player) => player.id !== challengerId)?.id;
-    if (!players.some((player) => player.id === targetId) && fallbackTarget) {
-      setTargetId(fallbackTarget);
-    } else if (challengerId && challengerId === targetId && fallbackTarget) {
-      setTargetId(fallbackTarget);
+    if (targetId && !players.some((player) => player.id === targetId)) {
+      setTargetId("");
+    }
+
+    if (challengerId && targetId && challengerId === targetId) {
+      setTargetId("");
     }
   }, [canPlay, players, challengerId, targetId]);
 
@@ -108,6 +109,9 @@ const DareComposer = ({ players, disabled, onLaunch }: DareComposerProps) => {
             <label>
               <span>Challenger</span>
               <select value={challengerId} onChange={(event) => setChallengerId(event.target.value)}>
+                <option value="" disabled>
+                  Select a challenger
+                </option>
                 {players.map((player) => (
                   <option key={player.id} value={player.id}>
                     {player.icon} {player.name}
@@ -119,7 +123,7 @@ const DareComposer = ({ players, disabled, onLaunch }: DareComposerProps) => {
               type="button"
               className="composer__swap"
               onClick={swapPlayers}
-              disabled={disabled}
+              disabled={disabled || !challengerId || !targetId}
               aria-label="Swap challenger and target"
             >
               ⇄
@@ -127,6 +131,9 @@ const DareComposer = ({ players, disabled, onLaunch }: DareComposerProps) => {
             <label>
               <span>Target</span>
               <select value={targetId} onChange={(event) => setTargetId(event.target.value)}>
+                <option value="" disabled>
+                  Select a target
+                </option>
                 {players
                   .filter((player) => player.id !== challengerId)
                   .map((player) => (


### PR DESCRIPTION
## Summary
- start the app with an empty player roster and move player selection directly under the introduction
- require challengers and targets to be chosen explicitly before launching a round

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68d3d9623cb0832c84acd094e9ca2308