### PR TITLE
Redesign interface with aligned timeline and glass cards

### DIFF
--- a/src/index.css
+++ b/src/index.css
@@ -1,51 +1,55 @@
-@import url("https://fonts.googleapis.com/css2?family=Outfit:wght@400;500;600;700&family=Space+Grotesk:wght@500;700&display=swap");
+@import url("https://fonts.googleapis.com/css2?family=Space+Grotesk:wght@500;600;700&family=Inter:wght@400;500;600;700&display=swap");
 
 :root {
   color-scheme: dark;
-  --bg: radial-gradient(circle at 0% 0%, rgba(56, 189, 248, 0.18), transparent 50%),
-    radial-gradient(circle at 100% 10%, rgba(244, 114, 182, 0.12), transparent 45%),
-    linear-gradient(180deg, #030510 0%, #01030a 100%);
-  --surface-primary: rgba(12, 17, 31, 0.88);
-  --surface-secondary: rgba(25, 33, 55, 0.78);
-  --surface-tertiary: rgba(45, 56, 86, 0.42);
-  --border-soft: rgba(148, 163, 184, 0.2);
-  --border-strong: rgba(148, 163, 184, 0.35);
+  --bg: radial-gradient(circle at 0% 0%, rgba(34, 197, 94, 0.24), transparent 55%),
+    radial-gradient(circle at 80% 10%, rgba(56, 189, 248, 0.3), transparent 45%),
+    linear-gradient(160deg, #020617 0%, #00040d 55%, #020617 100%);
+  --surface-primary: rgba(6, 11, 26, 0.72);
+  --surface-secondary: rgba(12, 18, 36, 0.86);
+  --surface-tertiary: rgba(18, 27, 52, 0.82);
+  --surface-dim: rgba(10, 16, 32, 0.7);
+  --border-soft: rgba(148, 163, 184, 0.22);
+  --border-strong: rgba(94, 234, 212, 0.5);
+  --border-highlight: rgba(59, 130, 246, 0.55);
   --text-primary: #f8fafc;
-  --text-secondary: rgba(226, 232, 240, 0.82);
-  --text-muted: rgba(148, 163, 184, 0.68);
-  --accent: #60a5fa;
-  --accent-strong: #38bdf8;
+  --text-secondary: rgba(226, 232, 240, 0.85);
+  --text-muted: rgba(148, 163, 184, 0.65);
+  --accent: #38bdf8;
+  --accent-strong: #22d3ee;
   --success: #34d399;
-  --shadow-soft: 0 28px 60px rgba(7, 9, 20, 0.55);
-  --radius-xl: 36px;
-  --radius-lg: 28px;
+  --warning: #fbbf24;
+  --danger: #f97316;
+  --radius-xl: 32px;
+  --radius-lg: 26px;
   --radius-md: 18px;
   --radius-sm: 14px;
   --max-width: 1180px;
-  --focus-ring: 0 0 0 2px rgba(96, 165, 250, 0.6), 0 0 0 6px rgba(96, 165, 250, 0.16);
+  --shadow-soft: 0 32px 80px rgba(3, 7, 18, 0.55);
+  --focus-ring: 0 0 0 1px rgba(59, 130, 246, 0.5), 0 0 0 6px rgba(59, 130, 246, 0.16);
 }
 
-@keyframes panelGlow {
+@keyframes floatGlow {
   0%,
   100% {
-    transform: translateY(0);
-    opacity: 0.18;
+    transform: translateY(0px) scale(1);
+    opacity: 0.6;
   }
   50% {
-    transform: translateY(-6px);
-    opacity: 0.45;
+    transform: translateY(-12px) scale(1.05);
+    opacity: 1;
   }
 }
 
-@keyframes progressShimmer {
+@keyframes pulseOutline {
   0% {
-    background-position: 0% 50%;
+    box-shadow: 0 0 0 0 rgba(56, 189, 248, 0.45);
   }
-  50% {
-    background-position: 100% 50%;
+  70% {
+    box-shadow: 0 0 0 14px rgba(56, 189, 248, 0);
   }
   100% {
-    background-position: 0% 50%;
+    box-shadow: 0 0 0 0 rgba(56, 189, 248, 0);
   }
 }
 
@@ -56,14 +60,17 @@
 body {
   margin: 0;
   min-height: 100vh;
-  font-family: "Outfit", system-ui, -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif;
+  font-family: "Inter", system-ui, -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif;
   background: var(--bg);
   color: var(--text-primary);
   -webkit-font-smoothing: antialiased;
+  display: flex;
+  justify-content: center;
 }
 
 #root {
   min-height: 100vh;
+  width: 100%;
 }
 
 a {
@@ -82,13 +89,13 @@ textarea {
 input,
 select,
 textarea {
-  background: var(--surface-secondary);
-  border: 1px solid var(--border-soft);
-  border-radius: var(--radius-md);
-  padding: 12px 14px;
   width: 100%;
+  border-radius: var(--radius-md);
+  border: 1px solid var(--border-soft);
+  background: rgba(12, 20, 38, 0.9);
+  padding: 12px 14px;
   color: var(--text-primary);
-  transition: border-color 0.2s ease, box-shadow 0.2s ease;
+  transition: border-color 0.2s ease, box-shadow 0.2s ease, transform 0.2s ease;
 }
 
 textarea {
@@ -107,10 +114,10 @@ select {
   appearance: none;
   background-image: linear-gradient(45deg, transparent 50%, var(--text-secondary) 50%),
     linear-gradient(135deg, var(--text-secondary) 50%, transparent 50%);
-  background-position: calc(100% - 16px) calc(50% - 6px), calc(100% - 12px) calc(50% - 6px);
+  background-position: calc(100% - 18px) calc(50% - 6px), calc(100% - 12px) calc(50% - 6px);
   background-size: 8px 8px, 8px 8px;
   background-repeat: no-repeat;
-  padding-right: 40px;
+  padding-right: 44px;
 }
 
 select:focus {
@@ -126,71 +133,84 @@ button {
   width: 100%;
   max-width: var(--max-width);
   margin: 0 auto;
-  padding: 32px 20px 72px;
-  display: flex;
-  flex-direction: column;
-  gap: 32px;
+  padding: 48px 24px 96px;
+  display: grid;
+  gap: 40px;
 }
 
 @media (min-width: 960px) {
   .app-frame {
-    padding: 48px 32px 96px;
-    gap: 40px;
+    padding: 64px 32px 120px;
+    gap: 48px;
   }
 }
 
 .app-header {
   position: relative;
-  background: var(--surface-primary);
+  background: linear-gradient(135deg, rgba(13, 20, 39, 0.92), rgba(2, 8, 23, 0.8));
   border-radius: var(--radius-xl);
-  border: 1px solid var(--border-soft);
-  padding: 28px;
+  border: 1px solid rgba(148, 163, 184, 0.18);
+  padding: 40px 32px;
   display: grid;
-  gap: 28px;
+  gap: 32px;
   overflow: hidden;
   box-shadow: var(--shadow-soft);
+  backdrop-filter: blur(22px);
+  isolation: isolate;
 }
 
 .app-header::before {
   content: "";
   position: absolute;
-  inset: -40% -20% auto 30%;
-  height: 320px;
-  background: radial-gradient(circle at center, rgba(96, 165, 250, 0.32), transparent 70%);
-  opacity: 0.7;
+  inset: -20% 30% auto -10%;
+  height: 380px;
+  background: radial-gradient(circle at center, rgba(59, 130, 246, 0.45), transparent 70%);
+  animation: floatGlow 14s ease-in-out infinite;
   pointer-events: none;
+  opacity: 0.7;
+  z-index: 0;
 }
 
-@media (min-width: 720px) {
-  .app-header {
-    padding: 36px 40px;
-  }
+.app-header::after {
+  content: "";
+  position: absolute;
+  inset: auto -10% -25% 35%;
+  height: 280px;
+  background: radial-gradient(circle at center, rgba(16, 185, 129, 0.3), transparent 70%);
+  opacity: 0.6;
+  filter: blur(4px);
+  pointer-events: none;
+  z-index: 0;
+}
+
+.app-header > * {
+  position: relative;
+  z-index: 1;
 }
 
 .app-header__bar {
   display: flex;
   justify-content: space-between;
   align-items: center;
-  gap: 18px;
-  position: relative;
-  z-index: 1;
+  gap: 20px;
 }
 
 .app-logo {
   display: flex;
   align-items: center;
-  gap: 12px;
+  gap: 14px;
 }
 
 .app-logo__mark {
-  width: 44px;
-  height: 44px;
-  border-radius: 16px;
+  width: 52px;
+  height: 52px;
+  border-radius: 18px;
   display: grid;
   place-items: center;
-  font-size: 1.6rem;
-  background: linear-gradient(135deg, rgba(96, 165, 250, 0.35), rgba(56, 189, 248, 0.7));
-  box-shadow: 0 18px 32px rgba(30, 64, 175, 0.35);
+  font-size: 1.9rem;
+  background: linear-gradient(135deg, rgba(59, 130, 246, 0.8), rgba(96, 165, 250, 0.4));
+  box-shadow: 0 24px 40px rgba(30, 64, 175, 0.42);
+  animation: pulseOutline 5s ease-in-out infinite;
 }
 
 .app-logo__text {
@@ -200,136 +220,119 @@ button {
 }
 
 .app-logo__title {
-  font-family: "Space Grotesk", sans-serif;
-  font-weight: 700;
-  letter-spacing: -0.01em;
+  font-family: "Space Grotesk", "Inter", sans-serif;
+  font-size: 1.4rem;
+  font-weight: 600;
+  letter-spacing: 0.01em;
 }
 
 .app-logo__tagline {
-  font-size: 0.75rem;
-  text-transform: uppercase;
-  letter-spacing: 0.24em;
+  font-size: 0.85rem;
   color: var(--text-muted);
 }
 
 .app-header__language {
-  display: inline-flex;
-  align-items: center;
-  gap: 10px;
-  background: rgba(15, 23, 42, 0.72);
-  border-radius: 999px;
-  padding: 6px 14px;
-  border: 1px solid rgba(148, 163, 184, 0.18);
-  font-size: 0.75rem;
-  letter-spacing: 0.14em;
-  text-transform: uppercase;
+  display: grid;
+  gap: 6px;
+  font-size: 0.85rem;
   color: var(--text-secondary);
 }
 
 .app-header__language select {
-  width: auto;
-  padding: 0 18px 0 8px;
-  border-radius: 999px;
-  background: transparent;
-  border: none;
-  box-shadow: none;
-  font-size: 0.85rem;
-  font-weight: 600;
-  letter-spacing: normal;
-}
-
-.app-header__language select:focus {
-  border: none;
-  box-shadow: none;
+  min-width: 160px;
 }
 
 .app-header__body {
   display: grid;
-  gap: 24px;
-  position: relative;
-  z-index: 1;
+  gap: 36px;
 }
 
-@media (min-width: 900px) {
+@media (min-width: 960px) {
   .app-header__body {
-    grid-template-columns: minmax(0, 1fr) minmax(240px, 320px);
-    align-items: end;
+    grid-template-columns: 1.05fr 0.95fr;
+    align-items: center;
   }
 }
 
 .app-header__copy {
   display: grid;
-  gap: 14px;
+  gap: 18px;
 }
 
 .app-header__eyebrow {
   margin: 0;
   text-transform: uppercase;
-  letter-spacing: 0.3em;
+  letter-spacing: 0.28em;
   font-size: 0.7rem;
-  color: var(--text-muted);
+  color: var(--accent);
 }
 
 .app-header__title {
   margin: 0;
-  font-size: clamp(2.2rem, 6vw, 3.1rem);
-  letter-spacing: -0.02em;
-  font-family: "Space Grotesk", sans-serif;
+  font-size: clamp(2.1rem, 4vw, 3.2rem);
+  font-family: "Space Grotesk", "Inter", sans-serif;
+  letter-spacing: -0.01em;
+  line-height: 1.1;
 }
 
 .app-header__subtitle {
   margin: 0;
-  font-size: 1.05rem;
-  line-height: 1.5;
   color: var(--text-secondary);
+  font-size: 1rem;
+  line-height: 1.65;
+  max-width: 520px;
 }
 
 .app-header__avatars {
-  display: inline-flex;
+  display: flex;
+  align-items: center;
   gap: 12px;
-  margin-top: 4px;
 }
 
 .app-header__avatars span {
-  width: 52px;
-  height: 52px;
-  border-radius: 18px;
+  width: 44px;
+  height: 44px;
+  border-radius: 14px;
   display: grid;
   place-items: center;
-  font-size: 1.8rem;
-  box-shadow: 0 18px 28px rgba(8, 11, 25, 0.45);
+  font-size: 1.5rem;
+  box-shadow: 0 12px 24px rgba(15, 23, 42, 0.36);
 }
 
 .app-header__stats {
-  margin: 0;
   display: grid;
-  grid-template-columns: repeat(3, minmax(0, 1fr));
-  gap: 12px;
-  padding: 22px;
-  background: rgba(15, 23, 42, 0.78);
+  gap: 18px;
+  padding: 26px;
   border-radius: var(--radius-lg);
-  border: 1px solid var(--border-soft);
-  box-shadow: inset 0 1px 0 rgba(255, 255, 255, 0.04);
+  background: rgba(12, 18, 36, 0.7);
+  border: 1px solid rgba(148, 163, 184, 0.22);
+  box-shadow: inset 0 1px 0 rgba(255, 255, 255, 0.05);
+}
+
+@media (min-width: 640px) {
+  .app-header__stats {
+    grid-template-columns: repeat(auto-fit, minmax(160px, 1fr));
+  }
 }
 
 .app-header__stats div {
   display: grid;
   gap: 6px;
-  justify-items: start;
 }
 
 .app-header__stats dt {
   margin: 0;
-  font-size: 0.75rem;
+  font-size: 0.72rem;
+  letter-spacing: 0.24em;
   text-transform: uppercase;
-  letter-spacing: 0.2em;
   color: var(--text-muted);
 }
 
 .app-header__stats dd {
   margin: 0;
-  font-size: 1.6rem;
+  font-size: 1.9rem;
   font-weight: 600;
+  letter-spacing: -0.01em;
 }
 
 .app-main {
@@ -338,42 +341,56 @@ button {
 
 .app-grid {
   display: grid;
-  gap: 24px;
+  gap: 32px;
+}
+
+@media (min-width: 1024px) {
+  .app-grid {
+    grid-template-columns: minmax(0, 1.15fr) minmax(0, 0.85fr);
+    gap: 36px;
+  }
 }
 
 .app-grid__column {
-  display: flex;
-  flex-direction: column;
-  gap: 24px;
+  display: grid;
+  gap: 32px;
+  align-content: start;
 }
 
-@media (min-width: 1080px) {
-  .app-grid {
-    grid-template-columns: minmax(0, 1.1fr) minmax(0, 0.9fr);
-    gap: 28px;
+.app-grid__column--secondary {
+  position: relative;
+}
+
+@media (min-width: 1024px) {
+  .app-grid__column--secondary {
+    padding-top: 24px;
   }
 }
 
 .panel {
-  background: var(--surface-primary);
-  border-radius: var(--radius-lg);
-  border: 1px solid var(--border-soft);
-  padding: 26px;
-  display: grid;
-  gap: 20px;
-  box-shadow: var(--shadow-soft);
   position: relative;
+  background: linear-gradient(160deg, rgba(12, 19, 40, 0.92), rgba(7, 12, 26, 0.88));
+  border-radius: var(--radius-lg);
+  border: 1px solid rgba(148, 163, 184, 0.2);
+  padding: 30px;
+  display: grid;
+  gap: 24px;
+  box-shadow: var(--shadow-soft);
   overflow: hidden;
+  backdrop-filter: blur(20px);
+  isolation: isolate;
 }
 
-.panel::after {
+.panel::before {
   content: "";
   position: absolute;
-  inset: auto -30% -60% 30%;
+  inset: -40% -20% auto;
   height: 240px;
-  background: radial-gradient(circle at center, rgba(96, 165, 250, 0.18), transparent 70%);
-  opacity: 0.35;
+  background: radial-gradient(circle at center, rgba(56, 189, 248, 0.32), transparent 70%);
+  opacity: 0.55;
   pointer-events: none;
+  filter: blur(6px);
+  transform: rotate(-4deg);
 }
 
 .panel > * {
@@ -391,107 +408,575 @@ button {
 .panel__eyebrow {
   margin: 0;
   text-transform: uppercase;
-  letter-spacing: 0.28em;
+  letter-spacing: 0.24em;
   font-size: 0.68rem;
   color: var(--text-muted);
 }
 
 .panel__title {
   margin: 8px 0 0;
-  font-size: 1.4rem;
+  font-size: 1.5rem;
   letter-spacing: -0.01em;
 }
 
 .panel__badge {
-  background: rgba(96, 165, 250, 0.16);
-  color: var(--text-secondary);
+  display: inline-flex;
+  align-items: center;
+  padding: 6px 14px;
   border-radius: 999px;
-  padding: 6px 12px;
+  background: rgba(56, 189, 248, 0.18);
+  border: 1px solid rgba(56, 189, 248, 0.35);
   font-size: 0.7rem;
-  letter-spacing: 0.18em;
+  letter-spacing: 0.16em;
   text-transform: uppercase;
+  color: var(--text-secondary);
 }
 
 .panel__description,
 .panel__empty,
 .panel__hint {
   margin: 0;
-  font-size: 0.95rem;
+  font-size: 0.98rem;
   color: var(--text-secondary);
+  line-height: 1.6;
+}
+
+.panel__empty {
+  color: var(--text-muted);
+  font-style: italic;
 }
 
 .panel__hint {
   color: var(--text-muted);
+  font-size: 0.85rem;
 }
 
 .button {
   display: inline-flex;
   align-items: center;
   justify-content: center;
-  gap: 8px;
+  gap: 10px;
   padding: 12px 18px;
-  border-radius: var(--radius-md);
-  border: none;
-  background: linear-gradient(135deg, var(--accent), var(--accent-strong));
-  color: white;
+  border-radius: var(--radius-sm);
+  border: 1px solid rgba(59, 130, 246, 0.45);
+  background: linear-gradient(135deg, rgba(59, 130, 246, 0.85), rgba(56, 189, 248, 0.65));
+  color: #0f172a;
   font-weight: 600;
-  min-height: 46px;
-  box-shadow: 0 18px 30px rgba(14, 116, 204, 0.35);
-  transition: transform 0.15s ease, box-shadow 0.2s ease, opacity 0.2s ease;
+  letter-spacing: 0.01em;
+  transition: transform 0.2s ease, box-shadow 0.2s ease, filter 0.2s ease;
 }
 
-.button:hover:not(:disabled) {
+.button:hover,
+.button:focus-visible {
   transform: translateY(-1px);
-  box-shadow: 0 22px 36px rgba(14, 116, 204, 0.42);
+  box-shadow: 0 18px 32px rgba(37, 99, 235, 0.4);
+  filter: brightness(1.05);
 }
 
 .button:disabled {
-  opacity: 0.5;
+  opacity: 0.6;
   cursor: not-allowed;
+  transform: none;
   box-shadow: none;
 }
 
 .button--ghost {
-  background: rgba(148, 163, 184, 0.16);
-  color: var(--text-secondary);
-  border: 1px solid rgba(148, 163, 184, 0.28);
-  box-shadow: none;
+  background: transparent;
+  color: var(--text-primary);
+  border-color: rgba(148, 163, 184, 0.3);
 }
 
-.button--ghost:hover:not(:disabled) {
-  background: rgba(148, 163, 184, 0.22);
+.button--ghost:hover,
+.button--ghost:focus-visible {
+  border-color: rgba(148, 163, 184, 0.6);
+  box-shadow: 0 18px 32px rgba(15, 23, 42, 0.4);
 }
 
 .text-button {
-  background: none;
+  background: transparent;
   border: none;
-  padding: 0;
-  color: var(--text-secondary);
+  color: var(--accent);
   font-weight: 500;
+  letter-spacing: 0.04em;
+  text-transform: uppercase;
+  font-size: 0.75rem;
+  transition: color 0.2s ease, opacity 0.2s ease;
+}
+
+.text-button:hover,
+.text-button:focus-visible {
+  color: var(--accent-strong);
+  opacity: 0.9;
+}
+
+.active-round__dare {
+  display: grid;
+  gap: 12px;
+  padding: 20px;
+  border-radius: var(--radius-md);
+  background: rgba(12, 20, 40, 0.78);
+  border: 1px solid rgba(59, 130, 246, 0.18);
+  box-shadow: inset 0 1px 0 rgba(148, 163, 184, 0.08);
+}
+
+.active-round__prompt {
+  margin: 0;
+  font-size: 1.08rem;
+  line-height: 1.6;
+}
+
+.active-round__stakes {
+  margin: 0;
+  font-size: 0.95rem;
+  color: var(--text-muted);
+}
+
+.active-round__steps {
+  display: grid;
+  gap: 20px;
+  align-items: stretch;
+}
+
+@media (min-width: 960px) {
+  .active-round__steps {
+    grid-template-columns: repeat(3, minmax(0, 1fr));
+  }
+}
+
+.active-round__step {
+  position: relative;
+  border: 1px solid rgba(148, 163, 184, 0.18);
+  border-radius: var(--radius-md);
+  padding: 22px;
+  display: grid;
+  gap: 18px;
+  background: rgba(9, 14, 30, 0.92);
+  box-shadow: 0 16px 40px rgba(2, 6, 23, 0.55);
+  min-height: 100%;
+  transition: transform 0.25s ease, border-color 0.25s ease, box-shadow 0.25s ease;
+  isolation: isolate;
+}
+
+.active-round__step::before {
+  content: "";
+  position: absolute;
+  inset: -40% -20% auto;
+  height: 200px;
+  background: radial-gradient(circle at center, rgba(56, 189, 248, 0.28), transparent 70%);
+  opacity: 0.4;
+  pointer-events: none;
+  transition: opacity 0.3s ease;
+  z-index: 0;
+}
+
+.active-round__step:not(:last-child)::after {
+  content: "";
+  position: absolute;
+  left: 34px;
+  top: calc(100% - 10px);
+  width: 2px;
+  height: 26px;
+  background: linear-gradient(180deg, rgba(56, 189, 248, 0.5), transparent);
+  opacity: 0.6;
+}
+
+@media (min-width: 960px) {
+  .active-round__step:not(:last-child)::after {
+    display: none;
+  }
+}
+
+.active-round__step:hover,
+.active-round__step:focus-within {
+  transform: translateY(-6px);
+  border-color: rgba(56, 189, 248, 0.5);
+  box-shadow: 0 24px 48px rgba(30, 64, 175, 0.38);
+}
+
+.active-round__step:hover::before,
+.active-round__step:focus-within::before {
+  opacity: 0.7;
+}
+
+.active-round__step.is-complete {
+  border-color: rgba(34, 197, 94, 0.45);
+  background: rgba(8, 26, 22, 0.85);
+}
+
+.active-round__step--highlight {
+  border-color: var(--border-highlight);
+  background: rgba(7, 16, 36, 0.95);
+  box-shadow: 0 24px 44px rgba(37, 99, 235, 0.4);
+}
+
+.active-round__step-header {
+  display: flex;
+  align-items: start;
+  gap: 16px;
+}
+
+.active-round__step-number {
+  width: 42px;
+  height: 42px;
+  border-radius: 14px;
+  display: grid;
+  place-items: center;
+  font-weight: 600;
+  background: linear-gradient(135deg, rgba(56, 189, 248, 0.45), rgba(14, 165, 233, 0.75));
+  color: #0f172a;
+  box-shadow: 0 14px 24px rgba(37, 99, 235, 0.42);
+}
+
+.active-round__step-title {
+  margin: 0;
+  font-size: 1.05rem;
+  letter-spacing: -0.01em;
+}
+
+.active-round__step-subtitle {
+  margin: 6px 0 0;
+  color: var(--text-muted);
+  font-size: 0.9rem;
+  line-height: 1.4;
+}
+
+.active-round__step-body {
+  display: grid;
+  gap: 14px;
+}
+
+.active-round__form {
+  display: grid;
+  gap: 14px;
+}
+
+.active-round__form-label {
+  font-size: 0.85rem;
+  letter-spacing: 0.06em;
+  text-transform: uppercase;
+  color: var(--text-muted);
+}
+
+.active-round__form input {
+  font-size: 1.05rem;
+  text-align: center;
+}
+
+.active-round__error {
+  margin: 0;
+  color: var(--danger);
+  font-size: 0.82rem;
   letter-spacing: 0.02em;
 }
 
-.text-button:hover:not(:disabled) {
-  color: var(--accent-strong);
+.active-round__step-message {
+  margin: 0;
+  color: var(--text-secondary);
+  line-height: 1.6;
 }
 
-.text-button:disabled {
-  opacity: 0.4;
-  cursor: not-allowed;
+.active-round__actions {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  gap: 12px;
 }
 
-label > span {
+.active-round__countdown {
+  display: grid;
+  place-items: center;
+  padding: 28px;
+  border-radius: var(--radius-md);
+  background: rgba(37, 99, 235, 0.12);
+  border: 1px solid rgba(59, 130, 246, 0.3);
+  gap: 8px;
+}
+
+.active-round__countdown span {
+  font-size: 3rem;
+  font-weight: 700;
+  font-family: "Space Grotesk", "Inter", sans-serif;
+}
+
+.active-round__countdown p {
+  margin: 0;
+  color: var(--text-muted);
+  letter-spacing: 0.18em;
+  text-transform: uppercase;
+  font-size: 0.7rem;
+}
+
+.active-round__hint {
+  font-size: 0.8rem;
+  color: var(--text-muted);
+}
+
+.active-round__reveal {
+  display: grid;
+  gap: 20px;
+  padding: 24px;
+  border-radius: var(--radius-md);
+  background: rgba(10, 24, 38, 0.85);
+  border: 1px solid rgba(56, 189, 248, 0.18);
+}
+
+.active-round__result {
+  margin: 0;
+  font-size: 1.4rem;
+  font-weight: 600;
+  text-align: center;
+  color: var(--danger);
+}
+
+.active-round__result.is-match {
+  color: var(--success);
+}
+
+.active-round__summary {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(160px, 1fr));
+  gap: 14px;
+}
+
+.active-round__summary-item {
+  display: grid;
+  gap: 6px;
+  padding: 16px;
+  border-radius: var(--radius-md);
+  border: 1px solid rgba(148, 163, 184, 0.18);
+  background: rgba(12, 20, 36, 0.8);
+}
+
+.active-round__summary-label {
+  color: var(--text-muted);
+  font-size: 0.8rem;
+  text-transform: uppercase;
+  letter-spacing: 0.12em;
+}
+
+.active-round__summary-value {
+  font-size: 1.5rem;
+  font-weight: 600;
+}
+
+.active-round__resolution {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 12px;
+  justify-content: center;
+}
+
+.active-round__resolved-note {
+  margin: 0;
+  color: var(--text-secondary);
+  text-align: center;
+}
+
+.composer {
+  display: grid;
+  gap: 20px;
+}
+
+.composer__row {
+  display: grid;
+  gap: 14px;
+}
+
+@media (min-width: 720px) {
+  .composer__row {
+    grid-template-columns: 1fr auto 1fr;
+    align-items: end;
+  }
+}
+
+.composer__row label span,
+.composer__field span {
   display: block;
   margin-bottom: 6px;
-  font-size: 0.82rem;
-  letter-spacing: 0.08em;
+  font-size: 0.8rem;
+  letter-spacing: 0.1em;
+  text-transform: uppercase;
+  color: var(--text-muted);
+}
+
+.composer__swap {
+  width: 42px;
+  height: 42px;
+  border-radius: 14px;
+  border: 1px solid rgba(59, 130, 246, 0.35);
+  background: rgba(15, 23, 42, 0.8);
+  color: var(--accent);
+  transition: transform 0.2s ease, box-shadow 0.2s ease;
+}
+
+.composer__swap:hover,
+.composer__swap:focus-visible {
+  transform: rotate(180deg);
+  box-shadow: 0 12px 24px rgba(37, 99, 235, 0.4);
+}
+
+.composer__field {
+  display: grid;
+}
+
+.composer__field textarea,
+.composer__field input {
+  background: rgba(12, 20, 36, 0.9);
+}
+
+.composer__odds {
+  display: flex;
+  justify-content: space-between;
+  gap: 18px;
+  align-items: center;
+  padding: 20px;
+  border-radius: var(--radius-md);
+  background: rgba(13, 23, 42, 0.85);
+  border: 1px solid rgba(56, 189, 248, 0.18);
+}
+
+.composer__odds p {
+  margin: 0;
+}
+
+.composer__odds-value {
+  font-size: 1.4rem;
+  font-weight: 600;
+  letter-spacing: -0.01em;
+}
+
+.composer__odds-value span {
+  display: inline-block;
+  margin-left: 10px;
+  padding: 4px 10px;
+  border-radius: 999px;
+  background: rgba(34, 197, 94, 0.22);
+  color: var(--success);
+  font-size: 0.8rem;
+  letter-spacing: 0.04em;
+  text-transform: uppercase;
+}
+
+.composer__odds input[type="range"] {
+  width: 180px;
+  accent-color: var(--accent);
+}
+
+.composer__launch {
+  display: flex;
+  justify-content: flex-end;
+}
+
+.history {
+  list-style: none;
+  margin: 0;
+  padding: 0;
+  display: grid;
+  gap: 20px;
+}
+
+.history__item {
+  position: relative;
+  padding: 22px;
+  border-radius: var(--radius-md);
+  background: rgba(11, 20, 36, 0.88);
+  border: 1px solid rgba(148, 163, 184, 0.16);
+  display: grid;
+  gap: 14px;
+}
+
+.history__item::before {
+  content: "";
+  position: absolute;
+  inset: -20% -10% auto;
+  height: 160px;
+  background: radial-gradient(circle at center, rgba(56, 189, 248, 0.22), transparent 70%);
+  opacity: 0.3;
+  pointer-events: none;
+}
+
+.history__item.is-match {
+  border-color: rgba(34, 197, 94, 0.35);
+  background: rgba(6, 20, 12, 0.85);
+}
+
+.history__meta {
+  display: flex;
+  justify-content: space-between;
+  gap: 16px;
+  font-size: 0.8rem;
+  text-transform: uppercase;
+  letter-spacing: 0.14em;
+  color: var(--text-muted);
+}
+
+.history__prompt {
+  margin: 0;
+  font-size: 1.02rem;
+  line-height: 1.6;
+}
+
+.history__stakes {
+  margin: 0;
+  font-size: 0.85rem;
+  color: var(--text-muted);
+}
+
+.history__players {
+  display: flex;
+  flex-wrap: wrap;
+  align-items: center;
+  gap: 12px;
+  font-size: 0.95rem;
+}
+
+.history__player {
+  display: inline-flex;
+  align-items: center;
+  gap: 8px;
+  padding: 6px 12px;
+  border-radius: 999px;
+  border: 1px solid currentColor;
+  background: rgba(15, 23, 42, 0.8);
+}
+
+.history__player span {
+  width: 26px;
+  height: 26px;
+  border-radius: 999px;
+  display: grid;
+  place-items: center;
+  font-size: 1rem;
+}
+
+.history__vs {
+  font-weight: 600;
+  letter-spacing: 0.12em;
+}
+
+.history__result {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  font-weight: 600;
+  color: var(--text-secondary);
+}
+
+.history__numbers {
+  font-size: 1.2rem;
+  letter-spacing: 0.04em;
+}
+
+.history__resolution {
+  font-size: 0.85rem;
+  letter-spacing: 0.12em;
   text-transform: uppercase;
   color: var(--text-muted);
 }
 
 .roster-form {
   display: grid;
-  gap: 16px;
+  gap: 18px;
 }
 
 .roster-form__input {
@@ -499,33 +984,50 @@ label > span {
   gap: 8px;
 }
 
+.roster-form__input span {
+  font-size: 0.8rem;
+  letter-spacing: 0.1em;
+  text-transform: uppercase;
+  color: var(--text-muted);
+}
+
 .roster-form__colors {
   display: grid;
-  grid-template-columns: repeat(auto-fit, minmax(44px, 1fr));
+  grid-template-columns: repeat(auto-fit, minmax(40px, 1fr));
   gap: 10px;
 }
 
 .roster-form__color {
-  height: 44px;
-  border-radius: var(--radius-sm);
+  width: 100%;
+  padding-bottom: 100%;
+  border-radius: 14px;
   border: 2px solid transparent;
-  box-shadow: inset 0 1px 0 rgba(255, 255, 255, 0.08);
+  position: relative;
   transition: transform 0.2s ease, border-color 0.2s ease;
 }
 
-.roster-form__color.is-active {
-  border-color: rgba(255, 255, 255, 0.8);
-  transform: translateY(-2px);
+.roster-form__color::after {
+  content: "";
+  position: absolute;
+  inset: 18%;
+  border-radius: inherit;
+  border: 2px solid rgba(255, 255, 255, 0.3);
 }
 
-.roster-form__colors button {
-  width: 100%;
+.roster-form__color:hover,
+.roster-form__color:focus-visible {
+  transform: translateY(-4px);
+}
+
+.roster-form__color.is-active {
+  border-color: rgba(248, 250, 252, 0.9);
+  box-shadow: 0 14px 28px rgba(15, 23, 42, 0.4);
 }
 
 .roster-form__hint {
   margin: 0;
-  font-size: 0.85rem;
-  color: var(--text-muted);
+  font-size: 0.8rem;
+  color: var(--warning);
 }
 
 .roster-list {
@@ -540,28 +1042,26 @@ label > span {
   display: flex;
   justify-content: space-between;
   align-items: center;
-  gap: 14px;
+  gap: 16px;
   padding: 14px 16px;
   border-radius: var(--radius-md);
-  border: 1px solid var(--border-soft);
-  background: rgba(15, 23, 42, 0.6);
-  backdrop-filter: blur(12px);
+  border: 1px solid currentColor;
+  background: rgba(15, 23, 42, 0.78);
 }
 
 .roster-list__identity {
   display: flex;
   align-items: center;
-  gap: 12px;
+  gap: 14px;
 }
 
 .roster-list__icon {
-  width: 46px;
-  height: 46px;
-  border-radius: 16px;
+  width: 40px;
+  height: 40px;
+  border-radius: 14px;
   display: grid;
   place-items: center;
-  font-size: 1.6rem;
-  box-shadow: 0 14px 22px rgba(8, 11, 25, 0.42);
+  font-size: 1.4rem;
 }
 
 .roster-list__name {
@@ -571,30 +1071,35 @@ label > span {
 
 .roster-list__stats {
   margin: 4px 0 0;
-  font-size: 0.82rem;
   color: var(--text-muted);
+  font-size: 0.85rem;
 }
 
 .roster-list__remove {
-  background: none;
+  width: 34px;
+  height: 34px;
+  border-radius: 12px;
   border: none;
-  color: var(--text-muted);
-  font-size: 1.4rem;
+  background: rgba(248, 113, 113, 0.16);
+  color: #fca5a5;
+  font-size: 1.2rem;
   line-height: 1;
-  padding: 6px;
+  transition: transform 0.2s ease, background 0.2s ease;
 }
 
-.roster-list__remove:hover {
-  color: rgba(248, 113, 113, 0.9);
+.roster-list__remove:hover,
+.roster-list__remove:focus-visible {
+  transform: translateY(-2px);
+  background: rgba(248, 113, 113, 0.3);
 }
 
 .roster-spotlight {
-  background: rgba(15, 23, 42, 0.6);
-  border-radius: var(--radius-md);
-  border: 1px solid var(--border-soft);
-  padding: 16px;
   display: grid;
   gap: 12px;
+  padding: 18px;
+  border-radius: var(--radius-md);
+  background: rgba(12, 20, 36, 0.82);
+  border: 1px solid rgba(148, 163, 184, 0.2);
 }
 
 .roster-spotlight__chips {
@@ -606,21 +1111,19 @@ label > span {
 .roster-spotlight__chip {
   display: inline-flex;
   align-items: center;
-  gap: 10px;
-  padding: 10px 14px;
+  gap: 8px;
+  padding: 6px 12px;
   border-radius: 999px;
   border: 1px solid currentColor;
-  font-size: 0.85rem;
-  background: rgba(15, 23, 42, 0.72);
+  background: rgba(15, 23, 42, 0.8);
 }
 
 .roster-spotlight__chip span {
-  width: 28px;
-  height: 28px;
+  width: 26px;
+  height: 26px;
+  border-radius: 999px;
   display: grid;
   place-items: center;
-  border-radius: 999px;
-  font-size: 1.1rem;
 }
 
 .roster-spotlight__chip.is-empty {
@@ -628,464 +1131,9 @@ label > span {
   border-style: dashed;
 }
 
-.active-round__dare {
-  display: grid;
-  gap: 10px;
-  padding: 18px;
-  border-radius: var(--radius-md);
-  background: rgba(148, 163, 184, 0.08);
-  border: 1px solid rgba(148, 163, 184, 0.18);
-}
-
-.active-round__prompt {
-  margin: 0;
-  font-size: 1.05rem;
-  line-height: 1.6;
-}
-
-.active-round__stakes {
-  margin: 0;
-  font-size: 0.9rem;
-  color: var(--text-muted);
-}
-
-.active-round__steps {
-  display: grid;
-  gap: 18px;
-  align-items: stretch;
-}
-
-@media (min-width: 880px) {
-  .active-round__steps {
-    grid-template-columns: repeat(auto-fit, minmax(240px, 1fr));
-    grid-auto-rows: 1fr;
-  }
-}
-
-.active-round__step {
-  position: relative;
-  border: 1px solid rgba(96, 165, 250, 0.12);
-  border-radius: var(--radius-md);
-  padding: 20px 18px;
-  background: rgba(15, 23, 42, 0.66);
-  display: flex;
-  flex-direction: column;
-  gap: 16px;
-  min-height: 100%;
-  transition: transform 0.25s ease, border-color 0.25s ease, box-shadow 0.25s ease;
-  overflow: hidden;
-}
-
-.active-round__step::before {
-  content: "";
-  position: absolute;
-  inset: -40% -20%;
-  background: radial-gradient(circle at center, rgba(96, 165, 250, 0.32), transparent 70%);
-  opacity: 0.18;
-  transition: opacity 0.3s ease;
-  z-index: 0;
-  filter: blur(10px);
-  animation: panelGlow 12s ease-in-out infinite;
-}
-
-.active-round__step:hover,
-.active-round__step:focus-within {
-  transform: translateY(-4px);
-  border-color: rgba(96, 165, 250, 0.35);
-  box-shadow: 0 18px 36px rgba(30, 64, 175, 0.28);
-}
-
-.active-round__step:hover::before,
-.active-round__step:focus-within::before {
-  opacity: 0.55;
-}
-
-.active-round__step > * {
-  position: relative;
-  z-index: 1;
-}
-
-.active-round__step-body {
-  display: grid;
-  gap: 12px;
-  flex: 1;
-}
-
-
-.active-round__step.is-complete {
-  border-color: rgba(52, 211, 153, 0.45);
-}
-
-.active-round__step--highlight {
-  border-color: rgba(96, 165, 250, 0.45);
-  box-shadow: 0 14px 28px rgba(37, 99, 235, 0.22);
-}
-
-.active-round__step--highlight::before {
-  background: radial-gradient(circle at center, rgba(96, 165, 250, 0.5), transparent 70%);
-}
-
-.active-round__step-header {
-  display: flex;
-  align-items: start;
-  gap: 16px;
-}
-
-.active-round__step-number {
-  width: 38px;
-  height: 38px;
-  border-radius: 12px;
-  background: linear-gradient(135deg, rgba(96, 165, 250, 0.35), rgba(56, 189, 248, 0.65));
-  display: grid;
-  place-items: center;
-  font-weight: 600;
-  box-shadow: 0 12px 22px rgba(30, 64, 175, 0.35);
-}
-
-.active-round__step-title {
-  margin: 0;
-  font-weight: 600;
-}
-
-.active-round__step-subtitle {
-  margin: 4px 0 0;
-  font-size: 0.85rem;
-  color: var(--text-muted);
-}
-
-.active-round__form {
-  display: grid;
-  gap: 12px;
-}
-
-.active-round__form label,
-.active-round__form-label {
-  font-size: 0.82rem;
-  color: var(--text-muted);
-  letter-spacing: 0.08em;
-  text-transform: uppercase;
-}
-
-.active-round__form input {
-  font-size: 1.1rem;
-  text-align: center;
-}
-
-.active-round__error {
-  margin: 0;
-  font-size: 0.82rem;
-  color: rgba(248, 113, 113, 0.9);
-}
-
-.active-round__actions {
-  display: flex;
-  justify-content: space-between;
-  align-items: center;
-  gap: 16px;
-}
-
-.active-round__step-message {
-  margin: 0;
-  font-size: 0.95rem;
-  color: var(--text-secondary);
-}
-
-.active-round__countdown {
-  display: grid;
-  justify-items: center;
-  gap: 6px;
-  font-size: 1.1rem;
-}
-
-.active-round__countdown span {
-  font-size: 2.6rem;
-  font-family: "Space Grotesk", sans-serif;
-  font-weight: 700;
-}
-
-.active-round__hint {
-  font-size: 0.82rem;
-  color: var(--text-muted);
-}
-
-.active-round__reveal {
-  display: grid;
-  gap: 16px;
-  background: rgba(15, 23, 42, 0.7);
-  border-radius: var(--radius-md);
-  border: 1px solid rgba(96, 165, 250, 0.22);
-  padding: 20px;
-}
-
-.active-round__result {
-  margin: 0;
-  font-size: 1.2rem;
-  font-weight: 600;
-  color: rgba(248, 113, 113, 0.9);
-}
-
-.active-round__result.is-match {
-  color: var(--success);
-}
-
-.active-round__summary {
-  display: grid;
-  gap: 10px;
-}
-
-@media (min-width: 520px) {
-  .active-round__summary {
-    grid-template-columns: repeat(2, minmax(0, 1fr));
-  }
-}
-
-.active-round__summary-item {
-  display: grid;
-  gap: 6px;
-  padding: 14px;
-  border-radius: var(--radius-sm);
-  background: rgba(96, 165, 250, 0.12);
-}
-
-.active-round__summary-label {
-  font-size: 0.85rem;
-  color: var(--text-muted);
-}
-
-.active-round__summary-value {
-  font-size: 1.4rem;
-  font-weight: 600;
-}
-
-.active-round__resolution {
-  display: flex;
-  flex-wrap: wrap;
-  gap: 10px;
-}
-
-.active-round__resolved-note {
-  margin: 0;
-  font-size: 0.9rem;
-  color: var(--text-muted);
-}
-
-.composer {
-  display: grid;
-  gap: 18px;
-}
-
-.composer__row {
-  display: grid;
-  gap: 12px;
-}
-
-@media (min-width: 640px) {
-  .composer__row {
-    grid-template-columns: repeat(2, minmax(0, 1fr));
-    align-items: end;
-  }
-}
-
-.composer__row label {
-  display: grid;
-  gap: 8px;
-}
-
-.composer__swap {
-  justify-self: center;
-  width: 48px;
-  height: 48px;
-  border-radius: 14px;
-  background: rgba(96, 165, 250, 0.16);
-  border: 1px solid rgba(96, 165, 250, 0.32);
-  color: var(--text-secondary);
-  font-size: 1.2rem;
-  box-shadow: 0 12px 24px rgba(30, 64, 175, 0.25);
-}
-
-.composer__swap:disabled {
-  opacity: 0.4;
-  box-shadow: none;
-}
-
-.composer__field {
-  display: grid;
-  gap: 8px;
-}
-
-.composer__odds {
-  display: flex;
-  flex-wrap: wrap;
-  justify-content: space-between;
-  align-items: center;
-  gap: 14px;
-  padding: 18px;
-  border-radius: var(--radius-md);
-  background: rgba(15, 23, 42, 0.64);
-  border: 1px solid rgba(96, 165, 250, 0.18);
-}
-
-.composer__odds p {
-  margin: 0;
-}
-
-.composer__odds-value {
-  font-size: 1.3rem;
-  font-weight: 600;
-  display: flex;
-  gap: 10px;
-  align-items: baseline;
-}
-
-.composer__odds-value span {
-  font-size: 0.75rem;
-  padding: 4px 10px;
-  border-radius: 999px;
-  background: rgba(96, 165, 250, 0.16);
-  text-transform: uppercase;
-  letter-spacing: 0.18em;
-}
-
-.composer input[type="range"] {
-  width: 100%;
-  accent-color: var(--accent);
-}
-
-.composer__footer {
-  display: flex;
-  flex-direction: column;
-  gap: 12px;
-  align-items: stretch;
-}
-
-@media (min-width: 560px) {
-  .composer__footer {
-    flex-direction: row;
-    justify-content: space-between;
-    align-items: center;
-  }
-
-  .composer__footer .button {
-    width: auto;
-    min-width: 180px;
-  }
-}
-
-.composer__hint {
-  margin: 0;
-  font-size: 0.85rem;
-  color: var(--text-muted);
-}
-
-.history {
-  margin: 0;
-  padding: 0;
-  list-style: none;
-  display: grid;
-  gap: 16px;
-}
-
-.history__item {
-  display: grid;
-  gap: 10px;
-  padding: 18px;
-  border-radius: var(--radius-md);
-  border: 1px solid rgba(148, 163, 184, 0.16);
-  background: rgba(15, 23, 42, 0.6);
-}
-
-.history__item.is-match {
-  border-color: rgba(52, 211, 153, 0.45);
-}
-
-.history__meta {
-  display: flex;
-  justify-content: space-between;
-  font-size: 0.8rem;
-  color: var(--text-muted);
-}
-
-.history__timestamp,
-.history__odds {
-  display: inline-flex;
-  gap: 6px;
-  align-items: center;
-}
-
-.history__odds {
-  text-transform: uppercase;
-  letter-spacing: 0.18em;
-  font-size: 0.68rem;
-}
-
-
-.history__prompt {
-  margin: 0;
-  font-size: 1rem;
-}
-
-.history__stakes {
-  margin: 0;
-  font-size: 0.85rem;
-  color: var(--text-muted);
-}
-
-.history__players {
-  display: flex;
-  align-items: center;
-  gap: 12px;
-  flex-wrap: wrap;
-}
-
-.history__player {
-  display: inline-flex;
-  align-items: center;
-  gap: 8px;
-  padding: 8px 12px;
-  border-radius: 999px;
-  border: 1px solid currentColor;
-  font-size: 0.85rem;
-}
-
-.history__player span {
-  width: 26px;
-  height: 26px;
-  display: grid;
-  place-items: center;
-  border-radius: 999px;
-  font-size: 1.1rem;
-}
-
-.history__vs {
-  font-size: 0.75rem;
-  letter-spacing: 0.28em;
-  text-transform: uppercase;
-  color: var(--text-muted);
-}
-
-.history__result {
-  display: flex;
-  justify-content: space-between;
-  align-items: center;
-  gap: 12px;
-  font-size: 0.9rem;
-}
-
-.history__numbers {
-  font-weight: 600;
-  font-size: 1.05rem;
-}
-
-.history__resolution {
-  text-transform: uppercase;
-  letter-spacing: 0.2em;
-  font-size: 0.7rem;
-  color: var(--text-muted);
-}
-
 .stats__grid {
   display: grid;
-  gap: 14px;
+  gap: 16px;
 }
 
 @media (min-width: 640px) {
@@ -1095,30 +1143,29 @@ label > span {
 }
 
 .stats__card {
+  padding: 20px;
+  border-radius: var(--radius-md);
+  background: rgba(11, 20, 38, 0.88);
+  border: 1px solid rgba(148, 163, 184, 0.2);
   display: grid;
   gap: 6px;
-  padding: 18px;
-  border-radius: var(--radius-md);
-  background: rgba(15, 23, 42, 0.62);
-  border: 1px solid rgba(148, 163, 184, 0.18);
 }
 
 .stats__label {
   margin: 0;
+  font-size: 0.82rem;
   text-transform: uppercase;
-  letter-spacing: 0.18em;
-  font-size: 0.75rem;
+  letter-spacing: 0.14em;
   color: var(--text-muted);
 }
 
 .stats__value {
   margin: 0;
-  font-size: 1.6rem;
+  font-size: 1.9rem;
   font-weight: 600;
 }
 
 .stats__note {
-  margin: 0;
   font-size: 0.85rem;
   color: var(--text-secondary);
 }
@@ -1126,45 +1173,44 @@ label > span {
 .stats__mvp {
   display: grid;
   gap: 12px;
+  padding: 22px;
+  border-radius: var(--radius-md);
+  background: rgba(12, 20, 36, 0.86);
+  border: 1px solid rgba(148, 163, 184, 0.22);
 }
 
 .stats__mvp-card {
   display: flex;
   align-items: center;
   gap: 16px;
-  padding: 18px;
+  padding: 16px;
   border-radius: var(--radius-md);
   border: 1px solid currentColor;
-  background: rgba(15, 23, 42, 0.6);
+  background: rgba(15, 23, 42, 0.85);
   position: relative;
   overflow: hidden;
 }
 
 .stats__mvp-burst {
   position: absolute;
-  width: 120px;
-  height: 120px;
-  border-radius: 999px;
-  opacity: 0.12;
+  inset: -20% auto auto -10%;
+  width: 160px;
+  height: 160px;
+  border-radius: 50%;
   filter: blur(12px);
-  inset: 50% auto auto -30px;
-}
-
-.stats__mvp-card > div {
-  position: relative;
-  z-index: 1;
+  opacity: 0.28;
 }
 
 .stats__mvp-name {
   margin: 0;
-  font-weight: 600;
   font-size: 1.1rem;
+  font-weight: 600;
 }
 
 .stats__mvp-note {
-  margin: 4px 0 0;
-  font-size: 0.85rem;
-  color: var(--text-secondary);
+  margin: 6px 0 0;
+  color: var(--text-muted);
+  font-size: 0.9rem;
 }
 
 .howto__carousel {
@@ -1175,38 +1221,37 @@ label > span {
 .howto__progress {
   display: flex;
   flex-direction: column;
-  gap: 10px;
+  gap: 8px;
 }
 
 .howto__progress-track {
   position: relative;
-  height: 8px;
+  height: 6px;
   border-radius: 999px;
-  background: rgba(148, 163, 184, 0.24);
+  background: rgba(148, 163, 184, 0.25);
   overflow: hidden;
 }
 
 .howto__progress-bar {
   position: absolute;
   inset: 0;
+  background: linear-gradient(90deg, rgba(56, 189, 248, 0.8), rgba(45, 212, 191, 0.9));
   border-radius: inherit;
-  background: linear-gradient(135deg, var(--accent), var(--accent-strong));
-  background-size: 200% 100%;
-  transition: width 0.4s ease, filter 0.4s ease;
-  animation: progressShimmer 8s linear infinite;
-  box-shadow: 0 10px 20px rgba(14, 116, 204, 0.35);
+  transition: width 0.3s ease;
 }
 
 .howto__progress-label {
-  font-size: 0.82rem;
+  font-size: 0.8rem;
+  letter-spacing: 0.12em;
+  text-transform: uppercase;
   color: var(--text-muted);
 }
 
 .howto__complete {
-  background: rgba(15, 23, 42, 0.65);
+  background: rgba(10, 24, 36, 0.86);
   border-radius: var(--radius-md);
-  padding: 20px;
-  border: 1px solid rgba(96, 165, 250, 0.28);
+  padding: 22px;
+  border: 1px solid rgba(34, 197, 94, 0.35);
   display: grid;
   gap: 8px;
 }
@@ -1224,10 +1269,10 @@ label > span {
 
 .howto__slide {
   position: relative;
-  background: rgba(15, 23, 42, 0.65);
+  background: rgba(10, 20, 36, 0.88);
   border-radius: var(--radius-md);
-  border: 1px solid rgba(148, 163, 184, 0.16);
-  padding: 22px;
+  border: 1px solid rgba(148, 163, 184, 0.2);
+  padding: 24px;
   display: grid;
   gap: 12px;
   overflow: hidden;
@@ -1237,40 +1282,35 @@ label > span {
 .howto__slide::before {
   content: "";
   position: absolute;
-  inset: -50% -30% auto;
-  height: 200px;
-  background: radial-gradient(circle at center, rgba(244, 114, 182, 0.24), transparent 70%);
-  opacity: 0.2;
+  inset: -50% -20% auto;
+  height: 220px;
+  background: radial-gradient(circle at center, rgba(244, 114, 182, 0.32), transparent 70%);
+  opacity: 0.25;
   transition: opacity 0.3s ease;
-  z-index: 0;
   pointer-events: none;
-}
-
-.howto__slide > * {
-  position: relative;
-  z-index: 1;
 }
 
 .howto__slide:hover,
 .howto__slide:focus-within {
-  transform: translateY(-4px);
-  box-shadow: 0 18px 32px rgba(15, 23, 42, 0.45);
+  transform: translateY(-6px);
+  box-shadow: 0 22px 36px rgba(15, 23, 42, 0.45);
 }
 
 .howto__slide:hover::before,
 .howto__slide:focus-within::before {
-  opacity: 0.45;
+  opacity: 0.6;
 }
 
 .howto__slide--advancing {
   opacity: 0.6;
+  filter: saturate(0.6);
 }
 
 .howto__slide-eyebrow {
   margin: 0;
   text-transform: uppercase;
-  letter-spacing: 0.24em;
-  font-size: 0.7rem;
+  letter-spacing: 0.18em;
+  font-size: 0.75rem;
   color: var(--text-muted);
 }
 
@@ -1295,33 +1335,45 @@ label > span {
   margin: 0;
   font-size: 0.85rem;
   color: var(--text-muted);
-  line-height: 1.4;
-}
-
-@media (min-width: 900px) {
-  .app-grid__column--secondary {
-    margin-top: 40px;
-  }
+  line-height: 1.5;
 }
 
 @media (max-width: 720px) {
-  .app-header__stats {
-    grid-template-columns: repeat(2, minmax(0, 1fr));
+  .app-frame {
+    padding: 32px 18px 80px;
   }
-}
 
-@media (max-width: 520px) {
   .app-header {
-    border-radius: var(--radius-lg);
-    padding: 24px;
+    padding: 32px 24px;
   }
 
   .panel {
-    border-radius: var(--radius-lg);
-    padding: 22px;
+    padding: 24px;
   }
 
   .app-header__stats {
     grid-template-columns: repeat(1, minmax(0, 1fr));
+  }
+}
+
+@media (max-width: 540px) {
+  .app-header__bar {
+    flex-direction: column;
+    align-items: flex-start;
+  }
+
+  .app-header__avatars span {
+    width: 36px;
+    height: 36px;
+  }
+
+  .active-round__actions {
+    flex-direction: column;
+    align-items: stretch;
+  }
+
+  .history__meta {
+    flex-direction: column;
+    align-items: flex-start;
   }
 }


### PR DESCRIPTION
## Summary
- refresh the global theme, hero header, and panel styling with a new neon glass aesthetic that scales cleanly toward mobile
- rework the active round timeline so the step cards stay aligned across sizes and introduce animated highlight states
- update supporting composer, history, roster, stats, and how-to panels to match the new layout and add playful motion cues

## Testing
- npm run build
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68d3fbce3a50832c924b128c96e8e9ed