### PR TITLE
Improve odds composer layout on small screens

### DIFF
--- a/src/index.css
+++ b/src/index.css
@@ -1202,13 +1202,21 @@ button {
 
 .composer__odds {
   display: flex;
-  justify-content: space-between;
+  flex-direction: column;
   gap: 18px;
-  align-items: center;
+  align-items: stretch;
   padding: 20px;
   border-radius: var(--radius-md);
   background: rgba(13, 23, 42, 0.85);
   border: 1px solid rgba(56, 189, 248, 0.18);
+}
+
+@media (min-width: 640px) {
+  .composer__odds {
+    flex-direction: row;
+    align-items: center;
+    justify-content: space-between;
+  }
 }
 
 .composer__odds p {
@@ -1234,8 +1242,14 @@ button {
 }
 
 .composer__odds input[type="range"] {
-  width: 180px;
+  width: 100%;
   accent-color: var(--accent);
+}
+
+@media (min-width: 640px) {
+  .composer__odds input[type="range"] {
+    width: min(220px, 100%);
+  }
 }
 
 .composer__launch {


### PR DESCRIPTION
## Summary
- adjust the odds composer layout to stack its contents vertically on narrow screens
- ensure the odds range slider shrinks to the container width on mobile while keeping the horizontal layout on larger viewports

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68d402343880832cac829e82e0f1cccf