### PR TITLE
Add header how-to link and streamline legacy guide access

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -233,10 +233,10 @@ const AppContent = () => {
   }, [players, activeRound]);
 
   useEffect(() => {
-    if (activeStage !== "legacy") {
+    if (activeStage !== "legacy" && insightOverlay === "stats") {
       setInsightOverlay(null);
     }
-  }, [activeStage]);
+  }, [activeStage, insightOverlay]);
 
   const heroPlayers = useMemo(() => players.slice(0, 3), [players]);
   const totalDaresCompleted = useMemo(
@@ -312,14 +312,6 @@ const AppContent = () => {
               >
                 <span>{t("app.flow.overlays.statsTrigger")}</span>
               </button>
-              <button
-                type="button"
-                className="app-legacy__portal"
-                onClick={() => setInsightOverlay("guide")}
-                disabled={insightOverlay === "guide"}
-              >
-                <span>{t("app.flow.overlays.guideTrigger")}</span>
-              </button>
             </div>
           </div>
         );
@@ -337,16 +329,26 @@ const AppContent = () => {
               <span className="app-logo__tagline">{t("app.hero.eyebrow")}</span>
             </div>
           </div>
-          <label className="app-header__language">
-            <span>{languageLabel}</span>
-            <select value={language} onChange={handleLanguageChange}>
-              {availableLanguages.map((code) => (
-                <option key={code} value={code}>
-                  {languageOptions[code]}
-                </option>
-              ))}
-            </select>
-          </label>
+          <div className="app-header__actions">
+            <button
+              type="button"
+              className="text-button app-header__howto"
+              onClick={() => setInsightOverlay("guide")}
+              disabled={insightOverlay === "guide"}
+            >
+              {t("app.flow.overlays.guideLink")}
+            </button>
+            <label className="app-header__language">
+              <span>{languageLabel}</span>
+              <select value={language} onChange={handleLanguageChange}>
+                {availableLanguages.map((code) => (
+                  <option key={code} value={code}>
+                    {languageOptions[code]}
+                  </option>
+                ))}
+              </select>
+            </label>
+          </div>
         </div>
         <div className="app-header__body">
           <div className="app-header__copy">

--- a/src/i18n.tsx
+++ b/src/i18n.tsx
@@ -55,7 +55,7 @@ const translations = {
           label: "Afterglow",
           title: "Relive the highlights",
           description:
-            "Review history, open the stats spotlight, or revisit the how-to guide.",
+            "Review history, open the stats spotlight, and use the header link anytime for the how-to walkthrough.",
         },
         controls: {
           prev: "Previous",
@@ -67,6 +67,7 @@ const translations = {
         overlays: {
           statsLabel: "Session stats spotlight",
           guideLabel: "How to play walkthrough",
+          guideLink: "How to play",
           statsTrigger: "Open stats spotlight",
           guideTrigger: "Open how-to guide",
         },
@@ -276,7 +277,7 @@ const translations = {
           label: "Afterglow",
           title: "Relive the highlights",
           description:
-            "Scroll the history, pop open the stats spotlight, or re-read the how-to guide.",
+            "Scroll the history, pop open the stats spotlight, and tap the header link anytime for the how-to walkthrough.",
         },
         controls: {
           prev: "Back",
@@ -288,6 +289,7 @@ const translations = {
         overlays: {
           statsLabel: "Stats spotlight",
           guideLabel: "How-to walkthrough",
+          guideLink: "How-to guide",
           statsTrigger: "Open stats spotlight",
           guideTrigger: "Open how-to guide",
         },
@@ -497,7 +499,7 @@ const translations = {
           label: "Nachglühen",
           title: "Highlights erneut erleben",
           description:
-            "Sieh dir den Verlauf an, öffne das Statistik-Spotlight oder lies die Anleitung erneut.",
+            "Sieh dir den Verlauf an, öffne das Statistik-Spotlight und nutze den Link im Header jederzeit für die Anleitung.",
         },
         controls: {
           prev: "Zurück",
@@ -509,6 +511,7 @@ const translations = {
         overlays: {
           statsLabel: "Statistik-Spotlight",
           guideLabel: "Spielanleitung",
+          guideLink: "Anleitung",
           statsTrigger: "Statistiken öffnen",
           guideTrigger: "Anleitung öffnen",
         },

--- a/src/index.css
+++ b/src/index.css
@@ -282,6 +282,40 @@ button {
   min-width: 160px;
 }
 
+.app-header__actions {
+  display: grid;
+  gap: 10px;
+  justify-items: end;
+}
+
+.app-header__howto {
+  border-radius: 999px;
+  padding: 6px 14px;
+  background: rgba(255, 255, 255, 0.18);
+  border: 1px solid rgba(10, 132, 255, 0.35);
+  box-shadow: 0 12px 26px rgba(10, 132, 255, 0.22);
+}
+
+.app-header__howto:hover,
+.app-header__howto:focus-visible {
+  background: rgba(10, 132, 255, 0.16);
+  box-shadow: 0 16px 32px rgba(10, 132, 255, 0.28);
+}
+
+.app-header__howto:disabled {
+  opacity: 0.65;
+  box-shadow: none;
+  cursor: default;
+}
+
+@media (min-width: 720px) {
+  .app-header__actions {
+    display: flex;
+    align-items: center;
+    gap: 18px;
+  }
+}
+
 .app-header__body {
   display: grid;
   gap: 36px;


### PR DESCRIPTION
## Summary
- replace the legacy-stage how-to portal with a compact "How to play" link in the header so the walkthrough is available anytime
- update overlay handling and styling to support the new header entry point and keep stats portal scoped to the afterglow stage
- refresh copy across locales to point players to the header link

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68d43d2901f4832cadf274073c66c123