### PR TITLE
Prevent horizontal scroll on mobile

### DIFF
--- a/src/index.css
+++ b/src/index.css
@@ -104,6 +104,7 @@ body {
   display: flex;
   justify-content: center;
   line-height: 1.6;
+  overflow-x: hidden;
 }
 
 #root {


### PR DESCRIPTION
## Summary
- prevent horizontal scrolling by hiding overflow on the body element

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68d4bacaf010832c8805ae81e9d0ffe2