### PR TITLE
Start experience at roster stage on load

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -159,9 +159,7 @@ const AppContent = () => {
   const [activeRound, setActiveRound] = useState<ActiveRound | null>(null);
   const [history, setHistory] = useState<RoundHistoryEntry[]>(persistedState.history);
   const [roundsLaunched, setRoundsLaunched] = useState<number>(persistedState.roundsLaunched);
-  const [activeStage, setActiveStage] = useState<ExperienceStage>(
-    persistedState.history.length > 0 ? "legacy" : "roster",
-  );
+  const [activeStage, setActiveStage] = useState<ExperienceStage>("roster");
   const [insightOverlay, setInsightOverlay] = useState<"stats" | "guide" | null>(null);
 
   const { t, language, setLanguage, languageLabel, languageOptions, availableLanguages } = useTranslation();


### PR DESCRIPTION
## Summary
- initialize the experience stage at the roster step regardless of saved history so new sessions always begin at the first step

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68d4bd01901c832c862187f1f22355b7