### PR TITLE
Show sequential stage explanations

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -432,6 +432,16 @@ const AppContent = () => {
     [stageMeta, stageStatuses, activeStage],
   );
 
+  const visibleStageSequence = useMemo(
+    () =>
+      stageSequence.filter(({ index }) => {
+        if (index === 0) return true;
+        const previousStageId = stageOrder[index - 1];
+        return stageCompletion[previousStageId];
+      }),
+    [stageSequence, stageOrder, stageCompletion],
+  );
+
   const quickStats = useMemo(
     () => [
       { label: t("app.hero.quickStats.players"), value: players.length },
@@ -603,7 +613,7 @@ const AppContent = () => {
         </section>
 
         <nav className="hud-steps" aria-label={t("app.flow.headline")}> 
-          {stageSequence.map(({ meta, status, isLocked, index }) => {
+          {visibleStageSequence.map(({ meta, status, isLocked, index }) => {
             const stepClass = [
               "hud-steps__item",
               `is-${status}`,
@@ -628,6 +638,8 @@ const AppContent = () => {
               >
                 <span className="hud-steps__index">{String(index + 1).padStart(2, "0")}</span>
                 <span className="hud-steps__label">{meta.label}</span>
+                <span className="hud-steps__title">{meta.title}</span>
+                <span className="hud-steps__description">{meta.description}</span>
               </button>
             );
           })}

--- a/src/index.css
+++ b/src/index.css
@@ -1286,7 +1286,7 @@ button {
 
 .hud-steps {
   display: grid;
-  grid-template-columns: repeat(auto-fit, minmax(180px, 1fr));
+  grid-template-columns: minmax(0, 1fr);
   gap: 16px;
 }
 
@@ -1333,6 +1333,31 @@ button {
   font-size: 1.02rem;
   font-weight: 600;
   letter-spacing: 0.04em;
+}
+
+.hud-steps__title {
+  display: block;
+  margin-top: 6px;
+  font-size: 1.12rem;
+  font-weight: 650;
+  letter-spacing: 0.02em;
+  color: var(--text-primary);
+}
+
+.hud-steps__item:not(.is-active) .hud-steps__title {
+  color: var(--text-secondary);
+}
+
+.hud-steps__description {
+  display: block;
+  margin-top: 10px;
+  font-size: 0.92rem;
+  line-height: 1.55;
+  color: var(--text-muted);
+}
+
+.hud-steps__item.is-active .hud-steps__description {
+  color: var(--text-secondary);
 }
 
 .hud-panel {


### PR DESCRIPTION
## Summary
- reveal stage cards sequentially so each step and its explanation only appear once the previous stage is complete
- surface stage titles and descriptions inside the step cards and adjust styling for the expanded content

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68d549929b64832cb1572bfebab5956a