### PR TITLE
Refine mobile step layout and copy

### DIFF
--- a/src/i18n.tsx
+++ b/src/i18n.tsx
@@ -37,25 +37,22 @@ const translations = {
         roster: {
           label: "Crew setup",
           title: "Assemble the crew",
-          description: "Add every player, assign colors and icons, and hype the reveal energy.",
+          description: "Add players and choose their look.",
         },
         dare: {
           label: "Dare forge",
           title: "Build the dare",
-          description:
-            "Pick challenger and target, tune the odds, and add a sweetener before launch.",
+          description: "Select challenger, target, and odds.",
         },
         round: {
           label: "Countdown arena",
           title: "Run the showdown",
-          description:
-            "Collect the secret picks, launch the countdown, and resolve the dare with style.",
+          description: "Collect picks and run the countdown.",
         },
         legacy: {
           label: "Afterglow",
           title: "Relive the highlights",
-          description:
-            "Review history, step into the trophy room, and use the header link anytime for the how-to walkthrough.",
+          description: "Review results and visit the trophy room.",
         },
         controls: {
           prev: "Previous",
@@ -275,26 +272,22 @@ const translations = {
         roster: {
           label: "Crew muster",
           title: "Rally the crew",
-          description:
-            "Add every legend, pick their colours and emoji, and set the vibe before things kick off.",
+          description: "Add the crew and pick their vibe.",
         },
         dare: {
           label: "Dare forge",
           title: "Spin the dare",
-          description:
-            "Lock in the stirrer and target, tweak the odds, and chuck in a sweetener before launch.",
+          description: "Choose who dares who and set the odds.",
         },
         round: {
           label: "Countdown pit",
           title: "Run the showdown",
-          description:
-            "Sneak the secret picks, fire the countdown, and see who owes the dare.",
+          description: "Lock the picks and fire the countdown.",
         },
         legacy: {
           label: "Afterglow",
           title: "Relive the highlights",
-          description:
-            "Scroll the history, duck into the trophy room, and tap the header link anytime for the how-to walkthrough.",
+          description: "Check the history and pop into the trophy room.",
         },
         controls: {
           prev: "Back",
@@ -514,26 +507,22 @@ const translations = {
         roster: {
           label: "Crew vorbereiten",
           title: "Team zusammenstellen",
-          description:
-            "Füge alle Mitspielenden hinzu, wähle Farben und Emojis und bringe Stimmung in die Runde.",
+          description: "Spieler:innen hinzufügen und Style wählen.",
         },
         dare: {
           label: "Mutprobe schmieden",
           title: "Mutprobe planen",
-          description:
-            "Lege Herausfordernde und Zielperson fest, passe die Odds an und ergänze einen Bonus vor dem Start.",
+          description: "Herausfordernde, Zielperson und Odds festlegen.",
         },
         round: {
           label: "Countdown-Arena",
           title: "Showdown starten",
-          description:
-            "Sammle die geheimen Zahlen, starte den Countdown und löse die Mutprobe auf.",
+          description: "Zahlen einsammeln und Countdown starten.",
         },
         legacy: {
           label: "Nachglühen",
           title: "Highlights erneut erleben",
-          description:
-            "Sieh dir den Verlauf an, öffne den Trophäenraum und nutze den Link im Header jederzeit für die Anleitung.",
+          description: "Verlauf prüfen und den Trophäenraum öffnen.",
         },
         controls: {
           prev: "Zurück",

--- a/src/index.css
+++ b/src/index.css
@@ -1465,32 +1465,202 @@ button {
 }
 
 @media (max-width: 640px) {
+  html,
+  body,
+  #root {
+    height: 100%;
+  }
+
+  body {
+    overflow: hidden;
+  }
+
   .holodeck {
-    padding: 24px 18px 48px;
+    padding: 20px 16px 32px;
+    min-height: 0;
+    height: 100%;
+    overflow: hidden;
+  }
+
+  .holodeck-frame {
+    min-height: 0;
+    height: 100%;
+    display: flex;
+    align-items: stretch;
   }
 
   .holodeck__hud {
-    gap: 24px;
-    padding: 24px;
+    gap: 18px;
+    padding: 18px;
+    height: 100%;
+    display: grid;
+    grid-template-rows: auto auto 1fr auto;
+    overflow: hidden;
   }
 
   .hud-header__buttons {
     width: 100%;
     justify-content: space-between;
+    gap: 8px;
   }
 
   .hud-header__actions {
     flex-direction: column;
     align-items: stretch;
-    gap: 16px;
+    gap: 12px;
   }
 
   .hud-header__language {
-    align-items: flex-start;
+    display: none;
+  }
+
+  .hud-header {
+    gap: 12px;
+  }
+
+  .hud-header__brand {
+    gap: 12px;
   }
 
   .hud-steps {
-    grid-template-columns: 1fr;
+    grid-template-columns: repeat(2, minmax(0, 1fr));
+    gap: 10px;
+  }
+
+  .hud-steps__item {
+    padding: 12px;
+  }
+
+  .hud-steps__index {
+    font-size: 0.68rem;
+  }
+
+  .hud-steps__label {
+    margin-top: 6px;
+    font-size: 0.82rem;
+  }
+
+  .hud-steps__title {
+    display: none;
+  }
+
+  .hud-steps__description {
+    margin-top: 6px;
+    font-size: 0.75rem;
+    line-height: 1.35;
+  }
+
+  .hud-status {
+    gap: 12px;
+  }
+
+  .hud-status__copy {
+    padding: 16px;
+  }
+
+  .hud-status__title {
+    font-size: 1.4rem;
+  }
+
+  .hud-status__subtitle {
+    margin: 8px 0 12px;
+    font-size: 0.85rem;
+    line-height: 1.4;
+  }
+
+  .hud-status__progress {
+    height: 6px;
+  }
+
+  .hud-status__metrics {
+    display: none;
+  }
+
+  .hud-panel {
+    padding: 16px;
+    min-height: 0;
+  }
+
+  .hud-panel__inner {
+    display: flex;
+    align-items: stretch;
+    height: 100%;
+    overflow: hidden;
+  }
+
+  .hud-panel__inner > * {
+    flex: 1;
+    min-height: 0;
+  }
+
+  .panel {
+    padding: 18px;
+    gap: 16px;
+    display: flex;
+    flex-direction: column;
+  }
+
+  .panel__header {
+    flex-direction: column;
+    align-items: flex-start;
+    gap: 8px;
+  }
+
+  .panel__title {
+    font-size: 1.2rem;
+  }
+
+  .panel__badge {
+    align-self: flex-start;
+  }
+
+  .panel__description,
+  .panel__empty,
+  .panel__hint {
+    font-size: 0.85rem;
+    line-height: 1.4;
+  }
+
+  .button {
+    padding: 12px 18px;
+    font-size: 0.78rem;
+  }
+
+  .hud-actions {
+    display: grid;
+    grid-template-columns: repeat(2, minmax(0, 1fr));
+    gap: 10px;
+  }
+
+  .hud-actions__button {
+    min-width: 0;
+    width: 100%;
+  }
+
+  .roster-form {
+    gap: 14px;
+  }
+
+  .roster-form__colors {
+    grid-template-columns: repeat(4, minmax(0, 1fr));
+  }
+
+  .roster-list {
+    gap: 10px;
+  }
+
+  .roster-list li {
+    padding: 10px 12px;
+  }
+
+  .roster-list__icon {
+    width: 36px;
+    height: 36px;
+    font-size: 1.2rem;
+  }
+
+  .roster-spotlight {
+    display: none;
   }
 }
 


### PR DESCRIPTION
## Summary
- Shorten the stage descriptions in every language to keep step explanations concise
- Rework the mobile HUD layout to use a full-height grid with tighter spacing and no vertical scrolling
- Hide or compact secondary elements on small screens so each step fits comfortably on a mobile viewport

## Testing
- npm run build *(fails: vite cannot resolve three/src/renderers/webgpu/WebGPURenderer.js)*

------
https://chatgpt.com/codex/tasks/task_e_68d54b2cb688832c9ba970a4fab8ddc2