### PR TITLE
Show only active how-to step

### DIFF
--- a/src/components/HowToPlayCard.tsx
+++ b/src/components/HowToPlayCard.tsx
@@ -1,4 +1,4 @@
-import { CSSProperties, useEffect, useRef, useState } from "react";
+import { useEffect, useState } from "react";
 import { useTranslation } from "../i18n";
 
 const ADVANCE_DELAY_MS = 800;
@@ -7,45 +7,24 @@ const RESTART_DELAY_MS = 2200;
 const HowToPlayCard = () => {
   const { t, dictionary } = useTranslation();
   const steps = dictionary.howTo.steps;
-  const [advancingIndex, setAdvancingIndex] = useState<number | null>(null);
   const [stepIndex, setStepIndex] = useState(0);
   const [isAdvancing, setIsAdvancing] = useState(false);
   const [isComplete, setIsComplete] = useState(false);
-  const resetAdvancingTimer = useRef<number | null>(null);
-
-  useEffect(() => {
-    return () => {
-      if (resetAdvancingTimer.current) {
-        window.clearTimeout(resetAdvancingTimer.current);
-      }
-    };
-  }, []);
 
   useEffect(() => {
     if (!isAdvancing) return;
 
     const timer = window.setTimeout(() => {
-      let reachedEnd = false;
-
       setStepIndex((current) => {
         const next = current + 1;
         if (next >= steps.length) {
           setIsComplete(true);
-          reachedEnd = true;
           return current;
         }
         return next;
       });
 
       setIsAdvancing(false);
-
-      if (resetAdvancingTimer.current) {
-        window.clearTimeout(resetAdvancingTimer.current);
-      }
-      resetAdvancingTimer.current = window.setTimeout(() => {
-        setAdvancingIndex(null);
-        resetAdvancingTimer.current = null;
-      }, reachedEnd ? 360 : 240);
     }, ADVANCE_DELAY_MS);
 
     return () => window.clearTimeout(timer);
@@ -54,15 +33,9 @@ const HowToPlayCard = () => {
   useEffect(() => {
     if (!isComplete) return;
 
-    if (resetAdvancingTimer.current) {
-      window.clearTimeout(resetAdvancingTimer.current);
-      resetAdvancingTimer.current = null;
-    }
-
     const timer = window.setTimeout(() => {
       setIsComplete(false);
       setStepIndex(0);
-      setAdvancingIndex(null);
     }, RESTART_DELAY_MS);
 
     return () => window.clearTimeout(timer);
@@ -70,7 +43,6 @@ const HowToPlayCard = () => {
 
   const handleCompleteStep = () => {
     if (isAdvancing || isComplete) return;
-    setAdvancingIndex(stepIndex);
     setIsAdvancing(true);
   };
 
@@ -87,10 +59,8 @@ const HowToPlayCard = () => {
     return null;
   }
 
-  type CardStyle = CSSProperties & {
-    "--stack-position"?: string;
-    "--completed-offset"?: string;
-  };
+  const currentStep = steps[stepIndex];
+  const isActive = !isComplete;
 
   return (
     <section className="panel howto">
@@ -110,77 +80,45 @@ const HowToPlayCard = () => {
           </span>
         </div>
         <div className="howto__card-stack" role="list">
-          {steps.map((step, index) => {
-            const position = index - stepIndex;
-            const isCurrent = index === stepIndex;
-            const isActive = isCurrent && !isComplete;
-            const isCompleted = index < stepIndex || (isCurrent && isComplete);
-            const isUpcoming = position > 0;
-            const isHidden = position > 3;
-            const isLeaving = advancingIndex === index;
-
-            const classNames = ["howto__card", "card-stack__card"];
-
-            if (isActive) classNames.push("howto__card--active", "card-stack__card--active");
-            if (isCurrent) classNames.push("howto__card--current", "card-stack__card--current");
-            if (isCompleted) classNames.push("howto__card--completed", "card-stack__card--completed");
-            if (isUpcoming) classNames.push("howto__card--upcoming", "card-stack__card--upcoming");
-            if (isHidden) classNames.push("howto__card--hidden", "card-stack__card--hidden");
-            if (isLeaving) classNames.push("howto__card--advancing", "card-stack__card--advancing");
-            if (isAdvancing && index === stepIndex + 1) {
-              classNames.push("howto__card--promoting", "card-stack__card--promoting");
-            }
-
-            const style: CardStyle = {
-              zIndex: steps.length - index,
-            };
-
-            if (isUpcoming) {
-              const clamped = Math.min(Math.max(position, 0), 3);
-              style["--stack-position"] = clamped.toString();
-            }
-
-            if (index < stepIndex) {
-              const depth = Math.min(stepIndex - index, 3);
-              style["--completed-offset"] = depth.toString();
-            }
-
-            return (
-              <article
-                key={`${step.title}-${index}`}
-                className={classNames.join(" ")}
-                style={style}
-                role="listitem"
-              >
-                <div className="howto__card-content card-stack__card-content">
-                  <p className="howto__card-eyebrow">
-                    {t("howTo.stepLabel", { current: index + 1 })}
-                  </p>
-                  <h3 className="howto__card-title">{step.title}</h3>
-                  <p className="howto__card-copy">{step.description}</p>
-                </div>
-                {isActive && (
-                  <div className="howto__card-actions card-stack__card-actions">
-                    <button
-                      type="button"
-                      className="button"
-                      onClick={handleCompleteStep}
-                      disabled={isAdvancing}
-                    >
-                      {stepIndex === steps.length - 1
-                        ? t("howTo.finish")
-                        : t("howTo.markComplete")}
-                    </button>
-                  </div>
-                )}
-                {isCompleted && (
-                  <div className="howto__card-status card-stack__card-status" aria-hidden="true">
-                    {t("howTo.completedLabel")}
-                  </div>
-                )}
-              </article>
-            );
-          })}
+          <article
+            className={[
+              "howto__card",
+              "card-stack__card",
+              "howto__card--current",
+              "card-stack__card--current",
+              ...(isActive
+                ? ["howto__card--active", "card-stack__card--active"]
+                : ["howto__card--completed", "card-stack__card--completed"]),
+            ].join(" ")}
+            role="listitem"
+          >
+            <div className="howto__card-content card-stack__card-content">
+              <p className="howto__card-eyebrow">
+                {t("howTo.stepLabel", { current: stepIndex + 1 })}
+              </p>
+              <h3 className="howto__card-title">{currentStep.title}</h3>
+              <p className="howto__card-copy">{currentStep.description}</p>
+            </div>
+            {isActive && (
+              <div className="howto__card-actions card-stack__card-actions">
+                <button
+                  type="button"
+                  className="button"
+                  onClick={handleCompleteStep}
+                  disabled={isAdvancing}
+                >
+                  {stepIndex === steps.length - 1
+                    ? t("howTo.finish")
+                    : t("howTo.markComplete")}
+                </button>
+              </div>
+            )}
+            {!isActive && (
+              <div className="howto__card-status card-stack__card-status" aria-hidden="true">
+                {t("howTo.completedLabel")}
+              </div>
+            )}
+          </article>
         </div>
         {isComplete && (
           <div className="howto__complete" role="status" aria-live="polite">


### PR DESCRIPTION
## Summary
- render only the currently active how-to step instead of the full card stack
- simplify the card component state now that stacked animations are removed

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68d623ff5a3c832cb4e1597a1c431b28