### PR TITLE
Fix composer inputs for dark theme readability

### DIFF
--- a/src/index.css
+++ b/src/index.css
@@ -2036,17 +2036,18 @@ button {
   width: 42px;
   height: 42px;
   border-radius: 14px;
-  border: 1px solid rgba(209, 213, 223, 0.7);
-  background: rgba(255, 255, 255, 0.85);
-  color: var(--accent);
-  box-shadow: 0 12px 24px rgba(15, 23, 42, 0.1);
-  transition: transform 0.2s ease, box-shadow 0.2s ease;
+  border: 1px solid var(--border-strong);
+  background: linear-gradient(160deg, rgba(18, 28, 64, 0.92), rgba(10, 18, 42, 0.92));
+  color: var(--accent-strong);
+  box-shadow: 0 16px 36px rgba(2, 8, 24, 0.6);
+  transition: transform 0.2s ease, box-shadow 0.2s ease, background 0.2s ease;
 }
 
 .composer__swap:hover,
 .composer__swap:focus-visible {
   transform: rotate(180deg);
-  box-shadow: 0 16px 30px rgba(10, 132, 255, 0.22);
+  background: linear-gradient(160deg, rgba(26, 40, 90, 0.98), rgba(12, 22, 52, 0.98));
+  box-shadow: 0 22px 44px rgba(10, 132, 255, 0.35);
 }
 
 .composer__field {
@@ -2055,7 +2056,9 @@ button {
 
 .composer__field textarea,
 .composer__field input {
-  background: rgba(255, 255, 255, 0.9);
+  background: linear-gradient(160deg, rgba(12, 20, 45, 0.92), rgba(7, 13, 33, 0.92));
+  border-color: var(--border-strong);
+  box-shadow: inset 0 0 0 1px rgba(94, 203, 255, 0.18), 0 22px 44px rgba(2, 8, 24, 0.55);
 }
 
 .composer__odds {
@@ -2065,9 +2068,9 @@ button {
   align-items: stretch;
   padding: 20px;
   border-radius: var(--radius-md);
-  background: rgba(255, 255, 255, 0.88);
-  border: 1px solid rgba(209, 213, 223, 0.7);
-  box-shadow: 0 18px 34px rgba(15, 23, 42, 0.1);
+  background: linear-gradient(165deg, rgba(14, 22, 52, 0.95), rgba(6, 12, 28, 0.95));
+  border: 1px solid var(--border-strong);
+  box-shadow: 0 26px 60px rgba(2, 8, 24, 0.65);
 }
 
 @media (min-width: 640px) {


### PR DESCRIPTION
## Summary
- restyle the dare composer swap control, inputs, and odds panel to use dark theme surfaces
- update hover treatments and shadows so controls remain legible against the background

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68d63fac269c832c943660d8adc4f825