### PR TITLE
Darken instructional and history cards

### DIFF
--- a/src/components/LinkDareInvitePage.tsx
+++ b/src/components/LinkDareInvitePage.tsx
@@ -101,7 +101,9 @@ const LinkDareInvitePage = ({ slug, token }: { slug: string; token: string }) =>
           matched: payload.matched,
         });
         setStatus("resolved");
-      } catch {}
+      } catch (_error) {
+        // Ignore malformed SSE payloads; heartbeat events can race with resolution
+      }
     });
     source.addEventListener("dare.expired", () => {
       setStatus("expired");

--- a/src/index.css
+++ b/src/index.css
@@ -2566,9 +2566,9 @@ button {
   position: relative;
   padding: 22px;
   border-radius: var(--radius-md);
-  background: rgba(255, 255, 255, 0.9);
-  border: 1px solid rgba(209, 213, 223, 0.7);
-  box-shadow: 0 20px 44px rgba(15, 23, 42, 0.1);
+  background: linear-gradient(170deg, rgba(18, 28, 66, 0.9), rgba(6, 14, 32, 0.92));
+  border: 1px solid var(--border-strong);
+  box-shadow: 0 30px 70px rgba(2, 6, 18, 0.6);
   display: grid;
   gap: 14px;
 }
@@ -2584,8 +2584,8 @@ button {
 }
 
 .history__item.is-match {
-  border-color: rgba(52, 199, 89, 0.4);
-  background: rgba(236, 253, 243, 0.92);
+  border-color: rgba(72, 245, 196, 0.45);
+  background: linear-gradient(170deg, rgba(12, 52, 42, 0.88), rgba(6, 32, 26, 0.92));
 }
 
 .history__meta {
@@ -2624,8 +2624,9 @@ button {
   gap: 8px;
   padding: 6px 12px;
   border-radius: 999px;
-  border: 1px solid currentColor;
-  background: rgba(255, 255, 255, 0.86);
+  border: 1px solid rgba(138, 124, 255, 0.5);
+  background: linear-gradient(160deg, rgba(18, 36, 82, 0.85), rgba(8, 20, 46, 0.92));
+  box-shadow: inset 0 0 0 1px rgba(94, 203, 255, 0.18);
 }
 
 .history__player span {
@@ -3116,12 +3117,13 @@ button {
 }
 
 .howto__complete {
-  background: rgba(255, 255, 255, 0.9);
+  background: linear-gradient(170deg, rgba(18, 40, 68, 0.9), rgba(8, 18, 36, 0.9));
   border-radius: var(--radius-md);
   padding: 22px;
-  border: 1px solid rgba(52, 199, 89, 0.35);
+  border: 1px solid rgba(72, 245, 196, 0.35);
   display: grid;
   gap: 8px;
+  box-shadow: 0 28px 60px rgba(2, 10, 26, 0.6);
 }
 
 .howto__complete-title {
@@ -3232,9 +3234,9 @@ button {
 .card-stack__card {
   position: absolute;
   inset: 0;
-  background: rgba(255, 255, 255, 0.94);
+  background: linear-gradient(165deg, rgba(18, 28, 66, 0.94), rgba(6, 12, 30, 0.92));
   border-radius: var(--radius-md);
-  border: 1px solid rgba(209, 213, 223, 0.68);
+  border: 1px solid var(--border-strong);
   padding: 26px 24px 24px;
   display: flex;
   flex-direction: column;
@@ -3243,7 +3245,7 @@ button {
   overflow: hidden;
   transform: translate3d(0, 0, 0);
   transform-style: preserve-3d;
-  box-shadow: 0 28px 48px rgba(15, 23, 42, 0.14);
+  box-shadow: 0 32px 68px rgba(2, 8, 24, 0.62);
   transition: transform 0.58s cubic-bezier(0.22, 1, 0.36, 1), opacity 0.4s ease,
     filter 0.4s ease, box-shadow 0.4s ease;
   pointer-events: none;


### PR DESCRIPTION
## Summary
- restyle the how-to carousel cards and completion panel with dark gradients to match the app theme
- apply the same dark surface treatment to history items and player chips shown after games resolve
- add a comment when swallowing malformed SSE payloads to satisfy lint rules

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68dc36ea8828832c8bf63f6cbd31878b