### PR TITLE
Make trophy room overlay scrollable

### DIFF
--- a/src/index.css
+++ b/src/index.css
@@ -1822,6 +1822,8 @@ button {
   display: flex;
   align-items: center;
   justify-content: center;
+  overflow-y: auto;
+  padding: clamp(24px, 8vh, 64px);
 }
 
 .holodeck-overlay__backdrop {
@@ -1839,7 +1841,10 @@ button {
   border: 1px solid rgba(120, 146, 255, 0.35);
   padding: clamp(24px, 5vw, 40px);
   width: min(720px, 90vw);
+  max-height: min(90vh, 960px);
   box-shadow: var(--shadow-soft);
+  display: flex;
+  flex-direction: column;
 }
 
 .holodeck-overlay__close {
@@ -1856,6 +1861,8 @@ button {
 
 .holodeck-overlay__content {
   margin-top: 24px;
+  flex: 1 1 auto;
+  overflow-y: auto;
 }
 
 @media (max-width: 960px) {


### PR DESCRIPTION
## Summary
- allow the trophy room overlay to scroll by giving the panel a max height and overflow handling
- ensure the overlay container itself can scroll with viewport padding so content remains accessible

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68dc395b80b0832ca089d5420abde05f